### PR TITLE
Typeable instances for everything [fixes #1]

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@
 
 ## Usage
 
-To use `base-orphans`, simply `import BaseOrphans ()`.
+To use `base-orphans`, simply `import Data.Orphans ()`.
 
 ## What is covered
 
@@ -25,6 +25,7 @@ To use `base-orphans`, simply `import BaseOrphans ()`.
  * `Num` instance for `Sum` and `Product`
  * `Storable` instance for `Complex` and `Ratio`
  * `Traversable` instance for `Either`, `(,)` and `Const`
+ * `Typeable` instance for most data types and typeclasses (when possible)
 
 ## Supported versions of GHC/`base`
 

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -40,7 +40,7 @@ library
       src
   
   exposed-modules:
-      BaseOrphans
+      Data.Orphans
   other-modules:
       Control.Applicative.Orphans
       Control.Exception.Orphans
@@ -49,6 +49,7 @@ library
       Data.Monoid.Orphans
       Data.Ord.Orphans
       Data.Traversable.Orphans
+      Data.Typeable.Orphans
       Data.Version.Orphans
       Foreign.Storable.Orphans
       GHC.Generics.Orphans

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -1,4 +1,8 @@
-module BaseOrphans () where
+{-|
+Exports orphan instances that mimic instances available in later versions of @base@.
+To use them, simply @import Data.Orphans ()@.
+-}
+module Data.Orphans () where
 
 import Control.Applicative.Orphans   ()
 import Control.Exception.Orphans     ()
@@ -8,6 +12,7 @@ import Data.Foldable.Orphans         ()
 import Data.Monoid.Orphans           ()
 import Data.Ord.Orphans              ()
 import Data.Traversable.Orphans      ()
+import Data.Typeable.Orphans         ()
 import Data.Version.Orphans          ()
 
 import Foreign.Storable.Orphans      ()

--- a/src/Data/Typeable/Orphans.hs
+++ b/src/Data/Typeable/Orphans.hs
@@ -1,0 +1,311 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
+
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
+
+{-# OPTIONS_GHC -fno-warn-deprecations -fno-warn-orphans #-}
+module Data.Typeable.Orphans () where
+
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative
+import Control.Exception
+import Control.Monad.ST.Lazy
+import Data.Char
+import Data.Data as Data
+import Data.Monoid as Monoid
+import Foreign.C.Error
+import Foreign.C.Types
+import Foreign.Marshal.Pool
+import GHC.Conc
+import GHC.IO.Buffer
+import GHC.IO.Device
+import GHC.IO.Encoding
+import System.Console.GetOpt
+import System.IO
+import System.IO.Error
+import Text.ParserCombinators.ReadP
+import Text.ParserCombinators.ReadPrec
+import Text.Read
+
+# if MIN_VERSION_base(4,2,0) && !MIN_VERSION_base(4,3,0)
+import Data.Unique
+# endif
+
+# if MIN_VERSION_base(4,4,0)
+import GHC.Event
+import GHC.Fingerprint
+import GHC.IO.Encoding.Failure
+# endif
+
+# if __GLASGOW_HASKELL__ >= 702
+import GHC.Generics as Generics
+# endif
+
+# if MIN_VERSION_base(4,5,0)
+import GHC.Stack
+import GHC.Stats
+# endif
+
+#if MIN_VERSION_base(4,6,0)
+import Data.Ord
+import GHC.TypeLits
+# endif
+
+# if MIN_VERSION_base(4,7,0)
+import Control.Concurrent.QSem
+import Text.Read.Lex
+# endif
+
+# if __GLASGOW_HASKELL__ >= 708
+import Control.Arrow
+import Control.Category
+import Control.Monad
+import Control.Monad.Fix
+import Control.Monad.Zip
+import Data.Bits
+import Data.Fixed
+import Data.Foldable
+import Data.Ix
+import Data.Traversable
+import Data.Type.Coercion
+import Data.Type.Equality
+import Foreign.Storable
+import GHC.Exts
+import GHC.IO.BufferedIO
+import GHC.IP
+import Text.Printf
+# endif
+#endif
+
+#if __GLASGOW_HASKELL__ < 710
+deriving instance Typeable  All
+deriving instance Typeable1 ArgDescr
+deriving instance Typeable1 ArgOrder
+deriving instance Typeable  Monoid.Any
+deriving instance Typeable  BlockReason
+deriving instance Typeable1 Buffer
+deriving instance Typeable3 BufferCodec
+deriving instance Typeable  BufferMode
+deriving instance Typeable  BufferState
+deriving instance Typeable  CFile
+deriving instance Typeable  CFpos
+deriving instance Typeable  CJmpBuf
+deriving instance Typeable2 Const
+deriving instance Typeable  Constr
+deriving instance Typeable  ConstrRep
+deriving instance Typeable  DataRep
+deriving instance Typeable  DataType
+deriving instance Typeable1 Dual
+deriving instance Typeable1 Endo
+deriving instance Typeable  Errno
+deriving instance Typeable1 First
+deriving instance Typeable  Data.Fixity
+deriving instance Typeable  GeneralCategory
+deriving instance Typeable  HandlePosn
+deriving instance Typeable1 Handler
+deriving instance Typeable  IODeviceType
+deriving instance Typeable  IOErrorType
+deriving instance Typeable  IOMode
+deriving instance Typeable1 Last
+deriving instance Typeable  Lexeme
+deriving instance Typeable  Newline
+deriving instance Typeable  NewlineMode
+deriving instance Typeable1 OptDescr
+deriving instance Typeable  Pool
+deriving instance Typeable1 Product
+deriving instance Typeable1 ReadP
+deriving instance Typeable1 ReadPrec
+deriving instance Typeable  SeekMode
+deriving instance Typeable2 ST
+deriving instance Typeable1 Sum
+deriving instance Typeable  TextEncoding
+deriving instance Typeable  ThreadStatus
+deriving instance Typeable1 ZipList
+
+#if MIN_VERSION_base(4,2,0) && !MIN_VERSION_base(4,3,0)
+deriving instance Typeable  Unique
+# endif
+
+# if MIN_VERSION_base(4,3,0)
+deriving instance Typeable  MaskingState
+# endif
+
+# if MIN_VERSION_base(4,4,0)
+deriving instance Typeable  CodingFailureMode
+deriving instance Typeable  CodingProgress
+deriving instance Typeable  Event
+deriving instance Typeable  EventManager
+deriving instance Typeable  FdKey
+deriving instance Typeable  Fingerprint
+deriving instance Typeable  TimeoutKey
+# endif
+
+# if __GLASGOW_HASKELL__ >= 702
+deriving instance Typeable  Arity
+deriving instance Typeable  Associativity
+deriving instance Typeable  C
+deriving instance Typeable  D
+deriving instance Typeable  Generics.Fixity
+deriving instance Typeable3 K1
+deriving instance Typeable  NoSelector
+deriving instance Typeable  P
+deriving instance Typeable1 Par1
+deriving instance Typeable  R
+deriving instance Typeable  S
+deriving instance Typeable1 U1
+deriving instance Typeable1 V1
+# endif
+
+# if MIN_VERSION_base(4,5,0)
+deriving instance Typeable  CostCentre
+deriving instance Typeable  CostCentreStack
+deriving instance Typeable  GCStats
+# endif
+
+# if MIN_VERSION_base(4,6,0)
+deriving instance Typeable1 Down
+deriving instance Typeable  Nat
+deriving instance Typeable  Symbol
+# endif
+
+# if MIN_VERSION_base(4,7,0)
+deriving instance Typeable FieldFormat
+deriving instance Typeable FormatAdjustment
+deriving instance Typeable FormatParse
+deriving instance Typeable FormatSign
+deriving instance Typeable Number
+deriving instance Typeable SomeNat
+deriving instance Typeable SomeSymbol
+deriving instance Typeable QSem -- This instance seems to have been removed
+                                -- (accidentally?) in base-4.7.0.0
+# endif
+
+# if __GLASGOW_HASKELL__ >= 708
+-- Data types which have more than seven type arguments
+deriving instance Typeable (,,,,,,,)
+deriving instance Typeable (,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+
+-- Data types which require PolyKinds
+deriving instance Typeable (:+:)
+deriving instance Typeable (:*:)
+deriving instance Typeable (:.:)
+deriving instance Typeable ArrowMonad
+deriving instance Typeable Kleisli
+deriving instance Typeable M1
+deriving instance Typeable Rec1
+deriving instance Typeable WrappedArrow
+deriving instance Typeable WrappedMonad
+
+-- Typeclasses
+deriving instance Typeable Arrow
+deriving instance Typeable ArrowApply
+deriving instance Typeable ArrowChoice
+deriving instance Typeable ArrowLoop
+deriving instance Typeable ArrowZero
+deriving instance Typeable Bits
+deriving instance Typeable Bounded
+deriving instance Typeable BufferedIO
+deriving instance Typeable Category
+deriving instance Typeable Coercible
+deriving instance Typeable Constructor
+deriving instance Typeable Data
+deriving instance Typeable Datatype
+deriving instance Typeable Enum
+deriving instance Typeable Exception
+deriving instance Typeable Eq
+deriving instance Typeable FiniteBits
+deriving instance Typeable Floating
+deriving instance Typeable Foldable
+deriving instance Typeable Fractional
+deriving instance Typeable Functor
+deriving instance Typeable Generic
+deriving instance Typeable Generic1
+deriving instance Typeable HasResolution
+deriving instance Typeable HPrintfType
+deriving instance Typeable Integral
+deriving instance Typeable IODevice
+deriving instance Typeable IP
+deriving instance Typeable IsChar
+deriving instance Typeable IsList
+deriving instance Typeable IsString
+deriving instance Typeable Ix
+deriving instance Typeable KnownNat
+deriving instance Typeable KnownSymbol
+deriving instance Typeable Monad
+deriving instance Typeable MonadFix
+deriving instance Typeable MonadPlus
+deriving instance Typeable MonadZip
+deriving instance Typeable Num
+deriving instance Typeable Ord
+deriving instance Typeable PrintfArg
+deriving instance Typeable PrintfType
+deriving instance Typeable RawIO
+deriving instance Typeable Read
+deriving instance Typeable Real
+deriving instance Typeable RealFloat
+deriving instance Typeable RealFrac
+deriving instance Typeable Selector
+deriving instance Typeable Show
+deriving instance Typeable Storable
+deriving instance Typeable TestCoercion
+deriving instance Typeable TestEquality
+deriving instance Typeable Traversable
+deriving instance Typeable Typeable
+# endif
+
+#endif

--- a/test/Control/Applicative/OrphansSpec.hs
+++ b/test/Control/Applicative/OrphansSpec.hs
@@ -1,8 +1,8 @@
 module Control.Applicative.OrphansSpec (main, spec) where
 
 import Test.Hspec
-import BaseOrphans ()
 import Control.Applicative
+import Data.Orphans ()
 import Data.Monoid
 import Prelude
 

--- a/test/Control/Exception/OrphansSpec.hs
+++ b/test/Control/Exception/OrphansSpec.hs
@@ -1,8 +1,8 @@
 module Control.Exception.OrphansSpec (main, spec) where
 
 import Test.Hspec
-import BaseOrphans ()
 import Control.Exception
+import Data.Orphans ()
 
 main :: IO ()
 main = hspec spec

--- a/test/Data/Bits/OrphansSpec.hs
+++ b/test/Data/Bits/OrphansSpec.hs
@@ -4,8 +4,8 @@ module Data.Bits.OrphansSpec (main, spec) where
 import Test.Hspec
 
 #if MIN_VERSION_base(4,6,0)
-import BaseOrphans ()
 import Data.Bits
+import Data.Orphans ()
 #endif
 
 main :: IO ()

--- a/test/Data/Foldable/OrphansSpec.hs
+++ b/test/Data/Foldable/OrphansSpec.hs
@@ -2,10 +2,10 @@ module Data.Foldable.OrphansSpec (main, spec) where
 
 import Test.Hspec
 
-import BaseOrphans ()
 import Control.Applicative
 import Data.Foldable as F
 import Data.Monoid
+import Data.Orphans ()
 import Prelude
 
 main :: IO ()

--- a/test/Data/Monoid/OrphansSpec.hs
+++ b/test/Data/Monoid/OrphansSpec.hs
@@ -1,8 +1,8 @@
 module Data.Monoid.OrphansSpec (main, spec) where
 
 import Test.Hspec
-import BaseOrphans ()
 import Data.Monoid
+import Data.Orphans ()
 
 main :: IO ()
 main = hspec spec

--- a/test/Data/Traversable/OrphansSpec.hs
+++ b/test/Data/Traversable/OrphansSpec.hs
@@ -2,8 +2,8 @@ module Data.Traversable.OrphansSpec (main, spec) where
 
 import Test.Hspec
 
-import BaseOrphans ()
 import Control.Applicative
+import Data.Orphans ()
 import Data.Traversable
 import Prelude
 

--- a/test/Data/Version/OrphansSpec.hs
+++ b/test/Data/Version/OrphansSpec.hs
@@ -6,8 +6,8 @@ module Data.Version.OrphansSpec (main, spec) where
 
 import Test.Hspec
 
-import BaseOrphans ()
 import Data.Data
+import Data.Orphans ()
 import Data.Version
 
 main :: IO ()

--- a/test/Foreign/Storable/OrphansSpec.hs
+++ b/test/Foreign/Storable/OrphansSpec.hs
@@ -1,8 +1,8 @@
 module Foreign.Storable.OrphansSpec (main, spec) where
 
 import Test.Hspec
-import BaseOrphans ()
 import Data.Complex
+import Data.Orphans ()
 import Data.Ratio
 import Foreign.Storable
 


### PR DESCRIPTION
This pull request (1) creates more parity with GHC 7.10 by creating `Typeable` instances for most data types and typeclasses (which GHC 7.10 does by default), and (2) aims for a new world record for the most standalone `deriving` statements in a single module.

@sol, can you review?