### PR TITLE
Show Fingerprint instance

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in next
+ - `Show` instance for `Fingerprint`
+
 ## Changes in 0.2.0
  - Drop GHC 6.12 (and `base-4.2.0.0`) compatibility
  - Fix Windows, GHCJS build

--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `Functor` instance for `ArgOrder`, `OptDescr`, and `ArgDescr`
  * `Num` instance for `Sum` and `Product`
  * `Read` instance for `Fixed`
+ * `Show` instance for `Fingerprint`
  * `Storable` instance for `Complex` and `Ratio`
  * `Traversable` instance for `Either`, `(,)` and `Const`
  * `Typeable` instance for most data types and typeclasses (when possible)

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.1.1.
+-- This file has been generated from package.yaml by hpack version 0.1.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -57,6 +57,7 @@ test-suite spec
       Data.Traversable.OrphansSpec
       Data.Version.OrphansSpec
       Foreign.Storable.OrphansSpec
+      GHC.Fingerprint.OrphansSpec
   build-depends:
       base >= 4.3 && < 5
 

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -23,6 +23,11 @@ To use them, simply @import Data.Orphans ()@.
 -}
 module Data.Orphans () where
 
+#if MIN_VERSION_base(4,4,0) && !(MIN_VERSION_base(4,7,0))
+import Data.Word (Word64)
+import Numeric (showHex)
+#endif
+
 #if !(MIN_VERSION_base(4,4,0))
 import Control.Concurrent.SampleVar
 import Control.Monad.ST as Strict
@@ -125,6 +130,16 @@ import GHC.IO.Encoding.CodePage.Table
 #endif
 
 -------------------------------------------------------------------------------
+
+#if MIN_VERSION_base(4,4,0) && !(MIN_VERSION_base(4,7,0))
+instance Show Fingerprint where
+    show (Fingerprint w1 w2) = hex16 w1 ++ hex16 w2
+      where
+        -- Formats a 64 bit number as 16 digits hex.
+        hex16 :: Word64 -> String
+        hex16 i = let hex = showHex i ""
+                   in replicate (16 - length hex) '0' ++ hex
+#endif
 
 #if !(MIN_VERSION_base(4,4,0))
 instance HasResolution a => Read (Fixed a) where

--- a/test/GHC/Fingerprint/OrphansSpec.hs
+++ b/test/GHC/Fingerprint/OrphansSpec.hs
@@ -3,9 +3,9 @@ module GHC.Fingerprint.OrphansSpec (main, spec) where
 
 import Test.Hspec
 
+#if MIN_VERSION_base(4,4,0)
 import Data.Orphans ()
 import Data.Word (Word64)
-#if MIN_VERSION_base(4,4,0)
 import GHC.Fingerprint.Type
 #endif
 

--- a/test/GHC/Fingerprint/OrphansSpec.hs
+++ b/test/GHC/Fingerprint/OrphansSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+module GHC.Fingerprint.OrphansSpec (main, spec) where
+
+import Test.Hspec
+
+import Data.Orphans ()
+import Data.Word (Word64)
+#if MIN_VERSION_base(4,4,0)
+import GHC.Fingerprint.Type
+#endif
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+#if MIN_VERSION_base(4,4,0)
+  describe "Fingerprint" $
+    it "has a Show instance" $ do
+      let w1, w2 :: Word64
+          w1 = 0x0123456789abcdef
+          w2 = 0x42
+          
+          f :: Fingerprint
+          f = Fingerprint w1 w2
+      show f `shouldBe` "0123456789abcdef0000000000000042"
+#else
+  return ()
+#endif


### PR DESCRIPTION
An easy-to-miss instance (which was introduced in `base-4.7.0.0`) lurking in `GHC.Fingerprint.Type`.