### PR TITLE
Eliminate RealFloat constraint for Storable Complex instance

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in next
+ - `Storable (Complex a)` instance no longer requires a `RealFloat a`
+   constraint if using `base-4.4` or later
+
 ## Changes in 0.3.1
  - `Functor`, `Applicative`, and `Monad` instances for `First` and `Last`
 

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -93,7 +93,7 @@ import Text.Printf
 #endif
 
 #if !(MIN_VERSION_base(4,8,0))
-import Data.Complex (Complex(..), realPart)
+import Data.Complex (Complex(..))
 import Data.Version
 import Foreign.Ptr (castPtr)
 import GHC.Real (Ratio(..), (%))
@@ -1161,12 +1161,16 @@ deriving instance Functor Last
 deriving instance Applicative Last
 deriving instance Monad Last
 
--- The actual constraint in base-4.8.0.0 doesn't include RealFloat a, but it
--- is needed in previous versions of base due to Complex having lots of
--- RealFloat constraints in its functions' type signatures.
-instance (Storable a, RealFloat a) => Storable (Complex a) where
-    sizeOf a       = 2 * sizeOf (realPart a)
-    alignment a    = alignment (realPart a)
+-- In base-4.3 and earlier, pattern matching on a Complex value invokes a
+-- RealFloat constraint due to the use of the DatatypeContexts extension.
+# if MIN_VERSION_base(4,4,0)
+instance Storable a
+# else
+instance (Storable a, RealFloat a)
+# endif
+  => Storable (Complex a) where
+    sizeOf (a :+ _)    = 2 * sizeOf a
+    alignment (a :+ _) = alignment a
     peek p           = do
                         q <- return $ castPtr p
                         r <- peek q


### PR DESCRIPTION
When I originally backported the orphan instance for `Storable (Complex a)`, I made a compromise and included a `RealFloat` constraint, since `realPart` required it up until `base-4.8`. I later realized that [this wasn't necessary](https://github.com/haskell-compat/base-compat/pull/31), so I changed the implementation from using `realPart` to pattern matching such that `base-4.4` and later don't require a `RealFloat` constraint.

(Alas, `Complex` using `DatatypeContexts` in `base-4.3` prevents this change from being uniform across all `base` versions, but there's nothing I can do about that.)

In addition, there's currently a [`storable-complex`](http://hackage.haskell.org/package/storable-complex) library on Hackage which exports this same instance, and I've wanted to request the author that they reexport this instance from `base-orphans`.