### PR TITLE
Typeable instances for promoted data constructors

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in next
+ - `Typeable` instances for `(~)`, `Any`, `Constraint`, `CSigset`, `Handler`,
+   `Opaque`, `SPEC`, and every promotable data constructor in `base`
+
 ## Changes in 0.3.2
  - `Storable (Complex a)` instance no longer requires a `RealFloat a`
    constraint if using `base-4.4` or later

--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `Show` instance for `Fingerprint`
  * `Storable` instance for `Complex` and `Ratio`
  * `Traversable` instance for `Either`, `(,)` and `Const`
- * `Typeable` instance for most data types and typeclasses (when possible)
+ * `Typeable` instance for most data types, typeclasses, and promoted data constructors (when possible)
 
 ## Supported versions of GHC/`base`
 

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -307,8 +307,8 @@ instance Selector S1_0_0All where
 
 -----
 
-instance Generic Any where
-    type Rep Any = D1 D1Any (C1 C1_0Any (S1 S1_0_0Any (Rec0 Bool)))
+instance Generic Monoid.Any where
+    type Rep Monoid.Any = D1 D1Any (C1 C1_0Any (S1 S1_0_0Any (Rec0 Bool)))
     from (Any a) = M1 (M1 (M1 (K1 a)))
     to (M1 (M1 (M1 (K1 a)))) = Any a
 

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -102,9 +102,6 @@ import Text.Printf
 
 # if defined(mingw32_HOST_OS)
 import GHC.ConsoleHandler as Console
-#  if !defined(__GHCJS__)
-import GHC.Conc.Windows
-#  endif
 # endif
 #endif
 
@@ -1679,23 +1676,10 @@ deriving instance Typeable 'ZipList
 
 #  if defined(mingw32_HOST_OS)
 deriving instance Typeable 'Break
-deriving instance Typeable 'Catch
-deriving instance Typeable 'Close
-deriving instance Typeable 'CompactArray
-deriving instance Typeable 'ControlC
-deriving instance Typeable 'ConvArray
-deriving instance Typeable 'Default
-deriving instance Typeable 'Ignore
-deriving instance Typeable 'Logoff
-deriving instance Typeable 'Shutdown
-deriving instance Typeable 'SingleByteCP
-#   if !defined(__GHCJS__)
-deriving instance Typeable 'Break
 deriving instance Typeable 'Close
 deriving instance Typeable 'ControlC
 deriving instance Typeable 'Logoff
 deriving instance Typeable 'Shutdown
-#   endif
 #  endif
 # endif
 


### PR DESCRIPTION
I forgot about yet another group of things that GHC 7.10 automatically derives `Typeable` instances for: promoted data constructors (e.g., `deriving instance Typeable 'Left`). In this pull request, I try my hardest to backport `Typeable` instances for every promotable data constructor in `base` (I _think_ I got them all, but I may have accidentally skipped some.) so that GHC 7.8 can use them.

I also added some `Typeable` instances for data types that I didn't catch last time; namely, for `(~)`, `Any`, `Constraint`, `CSigset`, `Handler`, `Opaque`, and `SPEC`.