### PR TITLE
Missing instances for Handler, ArrowMonad

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in next
+ - `Functor` instances for `Handler` and `ArrowMonad`. `Applicative`,
+   `Alternative`, and `MonadPlus` instances for `ArrowMonad`.
+
 ## Changes in 0.4.0
  - Removed all `Generic` and `Generic1` instances. These have been moved to the
    `generic-deriving` library.

--- a/README.markdown
+++ b/README.markdown
@@ -19,6 +19,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * Added `Applicative` and `Alternative` instances for `ReadP` and `ReadPrec`
  * Added `Eq` and `Ord` instances for `Control.Exception.ErrorCall`
  * Added `Eq`, `Ord`, `Read`, and `Show` instances for data types in `GHC.Generics`
+ * Added `Functor`, `Applicative`, `Alternative`, and `MonadPlus` instances for `ArrowMonad`
  * Added `Functor`, `Applicative`, and `Monad` instances for `First` and `Last`
  * Added `Monoid`, `Eq`, `Ord`, `Read`, and `Show` instances for `Const`
  * Added `Read` and `Show` instances for `Down`
@@ -28,7 +29,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `Applicative` instance for strict and lazy `ST`
  * `Bits` instance for `Bool`
  * `Foldable` instance for `Either`, `(,)` and `Const`
- * `Functor` instance for `ArgOrder`, `OptDescr`, and `ArgDescr`
+ * `Functor` instance for `Handler`, `ArgOrder`, `OptDescr`, and `ArgDescr`
  * `Num` instance for `Sum` and `Product`
  * `Read` instance for `Fixed`
  * `Show` instance for `Fingerprint`

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -245,8 +245,8 @@ instance Alternative ReadPrec where
     empty = mzero
     (<|>) = mplus
 
-instance Functor Handler where
-     fmap f (Handler h) = Handler (fmap f . h)
+instance Functor Exception.Handler where
+     fmap f (Exception.Handler h) = Exception.Handler (fmap f . h)
 
 instance
 # if MIN_VERSION_base(4,4,0)


### PR DESCRIPTION
My latest discovery in the hunt for undocumented instance additions to `base` uncovered that these were all added in `base-4.6` (seriously, how many of these things are there?):

* `Functor` instance for `Handler`
* `Functor`, `Applicative`, `Alternative`, and `MonadPlus` instances for `ArrowMonad`

I had to employ some CPP-fu to get around the fact that `ArrowMonad` had `ArrowApply` as a `DatatypeContext` in `base-4.3`, but otherwise, it's a fairly straightforward addition.