### PR TITLE
Bits, Bounded, and Integral instances for CDev

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -3,6 +3,7 @@
  - `Functor`. `Applicative`, `Alternative`, and `MonadPlus` instances for
    `ArrowMonad`
  - Expose `Read` and `Show` instances for `Down` on GHCs before 7.8
+ - `Bits`, `Bounded`, and `Integral` instances for `CDev`
 
 ## Changes in 0.4.1
  - Fixed imports on GHC < 7.8 on Windows

--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
 ## What is covered
 
  * Added `Applicative` and `Alternative` instances for `ReadP` and `ReadPrec`
+ * Added `Bits`, `Bounded`, and `Integral` instances for `CDev`
  * Added `Eq` and `Ord` instances for `Control.Exception.ErrorCall`
  * Added `Eq`, `Ord`, `Read`, and `Show` instances for data types in `GHC.Generics`
  * Added `Functor`, `Applicative`, `Alternative`, and `MonadPlus` instances for `ArrowMonad`

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -53,6 +53,7 @@ test-suite spec
       base >= 4.3 && < 5
     , base-orphans
     , hspec == 2.*
+    , QuickCheck
   other-modules:
       Control.Applicative.OrphansSpec
       Control.Exception.OrphansSpec
@@ -63,4 +64,5 @@ test-suite spec
       Data.Version.OrphansSpec
       Foreign.Storable.OrphansSpec
       GHC.Fingerprint.OrphansSpec
+      System.Posix.Types.OrphansSpec
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -51,3 +51,4 @@ tests:
     dependencies:
       - base-orphans
       - hspec == 2.*
+      - QuickCheck

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -31,7 +31,6 @@ To use them, simply @import Data.Orphans ()@.
 module Data.Orphans () where
 
 #if MIN_VERSION_base(4,4,0) && !(MIN_VERSION_base(4,7,0))
-import Data.Word (Word64)
 import Numeric (showHex)
 #endif
 
@@ -83,6 +82,10 @@ import System.Posix.Types
 import Control.Concurrent.QSem
 import Data.Proxy
 import Text.Read.Lex (Number)
+#endif
+
+#if !(MIN_VERSION_base(4,7,0))
+import Data.Word
 #endif
 
 #if __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -62,6 +62,10 @@ import GHC.Stack
 import GHC.Stats
 #endif
 
+#if !(MIN_VERSION_base(4,5,0))
+import Unsafe.Coerce (unsafeCoerce)
+#endif
+
 #if MIN_VERSION_base(4,6,0) && __GLASGOW_HASKELL__ < 710
 import GHC.ForeignPtr
 import GHC.GHCi
@@ -233,39 +237,35 @@ deriving instance Bits CDev
 deriving instance Bounded CDev
 deriving instance Integral CDev
 # else
-toCDev :: HTYPE_DEV_T -> CDev
-toCDev = fromIntegral
-
-fromCDev :: CDev -> HTYPE_DEV_T
-fromCDev = fromIntegral . fromEnum
+type HDev = HTYPE_DEV_T
 
 instance Bits CDev where
-    x .&.         y   = toCDev $ fromCDev x .&.   fromCDev y
-    x .|.         y   = toCDev $ fromCDev x .|.   fromCDev y
-    x `xor`       y   = toCDev $ fromCDev x `xor` fromCDev y
-    shift         x n = toCDev $ shift         (fromCDev x) n
-    rotate        x n = toCDev $ rotate        (fromCDev x) n
-    setBit        x n = toCDev $ setBit        (fromCDev x) n
-    clearBit      x n = toCDev $ clearBit      (fromCDev x) n
-    complementBit x n = toCDev $ complementBit (fromCDev x) n
-    testBit       x n = testBit (fromCDev x) n
-    complement        = toCDev . complement . fromCDev
-    bit               = toCDev . bit
-    bitSize           = bitSize  . fromCDev
-    isSigned          = isSigned . fromCDev
+    (.&.)         = unsafeCoerce ((.&.)         :: HDev -> HDev -> HDev)
+    (.|.)         = unsafeCoerce ((.|.)         :: HDev -> HDev -> HDev)
+    xor           = unsafeCoerce (xor           :: HDev -> HDev -> HDev)
+    shift         = unsafeCoerce (shift         :: HDev -> Int  -> HDev)
+    rotate        = unsafeCoerce (rotate        :: HDev -> Int  -> HDev)
+    setBit        = unsafeCoerce (setBit        :: HDev -> Int  -> HDev)
+    clearBit      = unsafeCoerce (clearBit      :: HDev -> Int  -> HDev)
+    complementBit = unsafeCoerce (complementBit :: HDev -> Int  -> HDev)
+    testBit       = unsafeCoerce (testBit       :: HDev -> Int  -> Bool)
+    complement    = unsafeCoerce (complement    :: HDev -> HDev)
+    bit           = unsafeCoerce (bit           :: Int  -> HDev)
+    bitSize       = unsafeCoerce (bitSize       :: HDev -> Int)
+    isSigned      = unsafeCoerce (isSigned      :: HDev -> Bool)
 
 instance Bounded CDev where
-    minBound = toCDev minBound
-    maxBound = toCDev maxBound
+    minBound = unsafeCoerce (minBound :: HDev)
+    maxBound = unsafeCoerce (maxBound :: HDev)
 
 instance Integral CDev where
-    x `quot`    y = toCDev $ fromCDev x `quot` fromCDev y
-    x `rem`     y = toCDev $ fromCDev x `rem`  fromCDev y
-    x `div`     y = toCDev $ fromCDev x `div`  fromCDev y
-    x `mod`     y = toCDev $ fromCDev x `mod`  fromCDev y
-    x `quotRem` y = let (q,r) = fromCDev x `quotRem` fromCDev y in (toCDev q, toCDev r)
-    x `divMod`  y = let (d,m) = fromCDev x `divMod`  fromCDev y in (toCDev d, toCDev m)
-    toInteger     = fromIntegral . fromCDev
+    quot      = unsafeCoerce (quot      :: HDev -> HDev -> HDev)
+    rem       = unsafeCoerce (rem       :: HDev -> HDev -> HDev)
+    div       = unsafeCoerce (div       :: HDev -> HDev -> HDev)
+    mod       = unsafeCoerce (mod       :: HDev -> HDev -> HDev)
+    quotRem   = unsafeCoerce (quotRem   :: HDev -> HDev -> (HDev, HDev))
+    divMod    = unsafeCoerce (divMod    :: HDev -> HDev -> (HDev, HDev))
+    toInteger = unsafeCoerce (toInteger :: HDev -> Integer)
 # endif
 
 instance Applicative ReadP where

--- a/test/System/Posix/Types/OrphansSpec.hs
+++ b/test/System/Posix/Types/OrphansSpec.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+module System.Posix.Types.OrphansSpec (main, spec) where
+
+import           Control.Applicative (liftA2)
+
+import           Data.Bits (Bits(..))
+import           Data.Orphans ()
+import           Data.Word
+
+import           System.Posix.Types
+
+import           Test.Hspec
+import           Test.Hspec.QuickCheck (prop)
+import           Test.QuickCheck (NonZero(..))
+
+#include "HsBaseConfig.h"
+
+type HDev = HTYPE_DEV_T
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "CDev" $ do
+  describe "Bits instance" $ do
+    prop "implements (.&.)" $
+      pred2HDevHDev (.&.) (.&.)
+    prop "implements (.|.)" $
+      pred2HDevHDev (.|.) (.|.)
+    prop "implements xor" $
+      pred2HDevHDev xor xor
+    prop "implements shift" $
+      pred2IntHDev shift shift
+    prop "implements rotate" $
+      pred2IntHDev rotate rotate
+    prop "implements setBit" $
+      pred2IntHDev setBit setBit
+    prop "implements clearBit" $
+      pred2IntHDev clearBit clearBit
+    prop "implements complementBit" $
+      pred2IntHDev complementBit complementBit
+    prop "implements testBit" $
+      pred2IntEq testBit testBit
+    prop "implements complement" $
+      pred1HDevHDev complement complement
+    prop "implements bit" $
+      pred1IntHDev bit bit
+    prop "implements bitSize" $
+      pred1HDevEq bitSize bitSize
+    prop "implements isSigned" $
+      pred1HDevEq isSigned isSigned
+  describe "Bounded instance" $ do
+    it "implements minBound" $
+      toInteger (minBound :: CDev) `shouldBe` toInteger (minBound :: HDev)
+    it "implements maxBound" $
+      toInteger (maxBound :: CDev) `shouldBe` toInteger (maxBound :: HDev)
+  describe "Integral instance" $ do
+    prop "implements quot" $
+      pred2HDevHDev quot quot
+    prop "implements rem" $
+      pred2HDevHDev rem rem
+    prop "implements div" $
+      pred2HDevHDev div div
+    prop "implements mod" $
+      pred2HDevHDev mod mod
+    prop "implements quotRem" $
+      pred2HDevPair quotRem quotRem
+    prop "implements divMod" $
+      pred2HDevPair divMod divMod
+    prop "implements toInteger" $
+      pred1HDevEq toInteger toInteger
+
+eqCDevHDev :: CDev -> HDev -> Bool
+eqCDevHDev cDev hDev = toInteger cDev == toInteger hDev
+
+pred1Common :: (b -> c -> d)
+            -> (a -> b)
+            -> (a -> c)
+            -> a -> d
+pred1Common = liftA2
+
+pred1HDev :: (b -> c -> Bool)
+          -> (CDev -> b)
+          -> (HDev -> c)
+          -> HDev -> Bool
+pred1HDev p f = pred1Common p (f . fromIntegral)
+
+pred1HDevEq :: Eq a => (CDev -> a) -> (HDev -> a) -> HDev -> Bool
+pred1HDevEq = pred1HDev (==)
+
+pred1HDevHDev :: (CDev -> CDev) -> (HDev -> HDev) -> HDev -> Bool
+pred1HDevHDev = pred1HDev eqCDevHDev
+
+pred1IntHDev :: (Int -> CDev) -> (Int -> HDev) -> Int -> Bool
+pred1IntHDev = pred1Common eqCDevHDev
+
+pred2Common :: (c -> d -> e)
+            -> (a -> b -> c)
+            -> (a -> b -> d)
+            -> a -> b -> e
+pred2Common p f g x y = p (f x y) (g x y)
+
+pred2HDev :: (a -> b -> Bool)
+          -> (CDev -> CDev -> a)
+          -> (HDev -> HDev -> b)
+          -> NonZero HDev -> NonZero HDev -> Bool
+pred2HDev eqv cDevPred hDevPred =
+  pred2Common eqv (\nz1 nz2 -> cDevPred (fromIntegral $ getNonZero nz1)
+                                        (fromIntegral $ getNonZero nz2))
+                  (\nz1 nz2 -> hDevPred (getNonZero nz1)
+                                        (getNonZero nz2))
+
+pred2HDevHDev :: (CDev -> CDev -> CDev)
+              -> (HDev -> HDev -> HDev)
+              -> NonZero HDev -> NonZero HDev -> Bool
+pred2HDevHDev = pred2HDev eqCDevHDev
+
+pred2HDevPair :: (CDev -> CDev -> (CDev, CDev))
+              -> (HDev -> HDev -> (HDev, HDev))
+              -> NonZero HDev -> NonZero HDev -> Bool
+pred2HDevPair = pred2HDev $ \(cDev1, cDev2) (hDev1, hDev2) ->
+     toInteger cDev1 == toInteger hDev1
+  && toInteger cDev2 == toInteger hDev2
+
+pred2Int :: (a -> b -> Bool)
+         -> (CDev -> Int -> a)
+         -> (HDev -> Int -> b)
+         -> HDev -> Int -> Bool
+pred2Int eqv cDevPred = pred2Common eqv (cDevPred . fromIntegral)
+
+pred2IntHDev :: (CDev -> Int -> CDev)
+             -> (HDev -> Int -> HDev)
+             -> HDev -> Int -> Bool
+pred2IntHDev = pred2Int eqCDevHDev
+
+pred2IntEq :: Eq a
+           => (CDev -> Int -> a)
+           -> (HDev -> Int -> a)
+           -> HDev -> Int -> Bool
+pred2IntEq = pred2Int (==)


### PR DESCRIPTION
Another poorly advertised change in GHC 7.6 added `Bits`, `Bounded`, and `Integral` instances for `CDev`.