### PR TITLE
Remove BOM from IntWord.hs

### DIFF
--- a/test/System/Posix/Types/IntWord.hs
+++ b/test/System/Posix/Types/IntWord.hs
@@ -1,4 +1,4 @@
-﻿module System.Posix.Types.IntWord (module IntWord) where
+module System.Posix.Types.IntWord (module IntWord) where
 
 import Data.Int  as IntWord
 import Data.Word as IntWord


### PR DESCRIPTION
For some reason tests didn't compile with GHC 7.10

```
root@d4e9cd691c24:/app/base-orphans-0.4.4# cabal test
Preprocessing library base-orphans-0.4.4...
In-place registering base-orphans-0.4.4...
Preprocessing test suite 'spec' for base-orphans-0.4.4...
test/System/Posix/Types/IntWord.hs: hLookAhead: invalid argument (invalid byte sequence)
root@d4e9cd691c24:/app/base-orphans-0.4.4# ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.10.2
root@d4e9cd691c24:/app/base-orphans-0.4.4# cabal --version
cabal-install version 1.22.6.0
using version 1.22.4.0 of the Cabal library 
root@d4e9cd691c24:/app/base-orphans-0.4.4# uname -a
Linux d4e9cd691c24 4.0.9-boot2docker #1 SMP Thu Sep 10 20:39:20 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
```