### PR TITLE
Backport new instances for GHC.Generics datatypes

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,9 @@
+## Changes in 0.5.2
+ - Backported `Enum`, `Bounded`, `Ix`, `Functor`, `Applicative`, `Monad`,
+   `MonadFix`, `MonadPlus`, `MonadZip`, `Foldable`, `Traversable`, and
+   `Data` instances for datatypes in the `GHC.Generics` module (introduced in
+   `base-4.9`)
+
 ## Changes in 0.5.1
  - The `Storable` instances for `Complex` and `Ratio` are now exactly as lazy
    as their counterparts in `base` (see issue

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -1,9 +1,9 @@
--- This file has been generated from package.yaml by hpack version 0.8.0.
+-- This file has been generated from package.yaml by hpack version 0.9.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:                base-orphans
-version:             0.5.1
+version:             0.5.2
 synopsis:            Backwards-compatible orphan instances for base
 description:         @base-orphans@ defines orphan instances that mimic instances available in later versions of @base@ to a wider (older) range of compilers. @base-orphans@ does not export anything except the orphan instances themselves and complements @<http://hackage.haskell.org/package/base-compat base-compat>@.
                      See the README for what instances are covered: <https://github.com/haskell-compat/base-orphans#readme>. See also the <https://github.com/haskell-compat/base-orphans#what-is-not-covered what is not covered> section.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: base-orphans
-version: 0.5.1
+version: 0.5.2
 synopsis: Backwards-compatible orphan instances for base
 license: MIT
 author:

--- a/src/Data/Orphans/Prelude.hs
+++ b/src/Data/Orphans/Prelude.hs
@@ -16,7 +16,7 @@ module Data.Orphans.Prelude
     (module OrphansPrelude, realPart, imagPart) where
 
 import Control.Applicative as OrphansPrelude
-import Control.Arrow as OrphansPrelude hiding (loop)
+import Control.Arrow as OrphansPrelude hiding (first, loop, second)
 import Control.Category as OrphansPrelude hiding ((.), id)
 import Control.Concurrent.QSem as OrphansPrelude
 import Control.Monad as OrphansPrelude hiding (mapM, sequence)
@@ -101,6 +101,7 @@ import Control.Concurrent.SampleVar as OrphansPrelude
 # endif
 
 # if MIN_VERSION_base(4,8,0)
+import Data.Bifunctor as OrphansPrelude
 import Data.Functor.Identity as OrphansPrelude
 # endif
 


### PR DESCRIPTION
This backports the changes introduced in a [recent GHC 8.0-rc commit](http://git.haskell.org/ghc.git/commit/673efccb3b348e9daf23d9e65460691bbea8586e) (addressing [Trac #9043](https://ghc.haskell.org/trac/ghc/ticket/9043)). This adds `Enum`, `Bounded`, `Ix`, `Functor`, `Applicative`, `Monad`, `MonadFix`, `MonadPlus`, `MonadZip`, `Foldable`, `Traversable`, and `Data` instances for datatypes in the `GHC.Generics` module.