### PR TITLE
Use hpack defaults from sol/hpack-defaults@hspec-cabal-new for tests

### DIFF
--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8e167d6c4df99d26fa070aa244f80031bf57961d753804d2f9fc882482cd944c
+-- hash: 8cf5bb1ad0b62fa0aa0712cdf76c9dcbaa56e2460426d686c5a6080fbc7c05ce
 
 name:                base-orphans
 version:             0.6

--- a/package.yaml
+++ b/package.yaml
@@ -56,12 +56,7 @@ library:
 
 tests:
   spec:
-    main: Spec.hs
-    source-dirs:
-      - test
+    defaults: sol/hpack-defaults@hspec-cabal-new
     dependencies:
       - base-orphans
-      - hspec == 2.*
       - QuickCheck
-    build-tool-depends:
-      - hspec-discover:hspec-discover == 2.*


### PR DESCRIPTION
(requires an sol/hpack@verbatim)

This is considered a temporary workaround, no guarantees that `sol/hpack@verbatim` will ever land on master!