### PR TITLE
Add Typeable Proxy for base-4.8.0.0

### DIFF
--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -1293,6 +1293,10 @@ deriving instance Typeable QSem -- This instance seems to have been removed
                                 -- (accidentally?) in base-4.7.0.0
 # endif
 
+#if MIN_VERSION_base(4,8,0)
+deriving instance Typeable Proxy
+#endif
+
 # if __GLASGOW_HASKELL__ >= 708
 -- Data types which use poly-kinded Typeable...
 deriving instance Typeable ArrowMonad


### PR DESCRIPTION
It's no in base-4.8.2.0t: https://hackage.haskell.org/package/base-4.8.2.0/docs/Data-Proxy.html,

It is however in base-4.7.0.0, which seems weird: https://hackage.haskell.org/package/base-4.7.0.0/docs/Data-Proxy.html

I didn't investigate more closely.