### PR TITLE
Synchronize `Solo`, `Fixed` instances with final GHC 9.2.1 release

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210827
+# version: 0.13.20211029
 #
-# REGENDATA ("0.13.20210827",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.13.20211029",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -26,15 +26,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.0.20210821
+          - compiler: ghc-9.2.1
             compilerKind: ghc
-            compilerVersion: 9.2.0.20210821
+            compilerVersion: 9.2.1
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
-            setup-method: ghcup
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -104,14 +104,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.4.0.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
-            apt-get install -y "$HCNAME" cabal-install-3.4
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -129,13 +133,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.4.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,12 @@
+## Changes in next [????.??.??]
+ - Backport `Eq`, `Ord`, `Bounded`, `Enum`, and `Ix` instances for `Solo`,
+   introduced in GHC 9.2/`base-4.16`
+ - Remove the backported `Eq1` and `Ord1` instances for `Fixed` that were
+   introduced in `base-orphans-0.8.5`. While these briefly appeared in a
+   release candidate version of GHC 9.2.1, they were ultimately removed from
+   the final 9.2.1 release. This release of `base-orphans` synchronizes with
+   that change.
+
 ## Changes in 0.8.5 [2021.08.29]
  - Backport new instances from GHC 9.2/`base-4.16`
    * `Eq1`, `Read1`, and `Show1` instances for `Complex`

--- a/README.markdown
+++ b/README.markdown
@@ -55,8 +55,8 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `Eq{1,2}`, `Ord{1,2}`, `Show{1,2}`, and `Read{1,2}` instances for `(,,)` and `(,,,)`
  * `Eq` and `Ord` instances for `Control.Exception.ErrorCall`
  * `Eq`, `Ord`, `Read`, and `Show` instances for data types in `GHC.Generics`
+ * `Eq`, `Ord`, `Bounded`, `Enum`, and `Ix` instances for `Solo`
  * `Eq1`, `Read1`, and `Show1` instances for `Complex`
- * `Eq1` and `Ord1` instances for `Fixed`
  * `Eq1`, `Ord1`, `Read1`, and `Show1` instances for `NonEmpty`
  * `Foldable` instance for `Either`, `(,)` and `Const`
  * `Foldable` and `Traversable` instances for `Alt` from `Data.Monoid`

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -35,7 +35,7 @@ copyright:           (c) 2012-2017 Simon Hengel,
 license:             MIT
 license-file:        LICENSE
 build-type:          Simple
-tested-with:         GHC == 7.0.4 , GHC == 7.2.2 , GHC == 7.4.2 , GHC == 7.6.3 , GHC == 7.8.4 , GHC == 7.10.3 , GHC == 8.0.2 , GHC == 8.2.2 , GHC == 8.4.4 , GHC == 8.6.5 , GHC == 8.8.4 , GHC == 8.10.7, GHC == 9.0.1, GHC == 9.2.*
+tested-with:         GHC == 7.0.4 , GHC == 7.2.2 , GHC == 7.4.2 , GHC == 7.6.3 , GHC == 7.8.4 , GHC == 7.10.3 , GHC == 8.0.2 , GHC == 8.2.2 , GHC == 8.4.4 , GHC == 8.6.5 , GHC == 8.8.4 , GHC == 8.10.7, GHC == 9.0.1, GHC == 9.2.1
 extra-source-files:
     CHANGES.markdown
     README.markdown

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,4 +2,3 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror
-ghcup-jobs:             >=8.10


### PR DESCRIPTION
This makes two additional GHC 9.2.1–related changes:

* This backports `Eq`, `Ord`, `Bounded`, `Enum`, and `Ix` instances for `Solo`. See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6453.
* This removes the `Eq1` and `Ord1` instances for `Fixed`, which were ultimately removed from the final GHC 9.2.1 release. See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6454.

Fixes #58. Fixes #56 (hopefully for good this time).