### PR TITLE
Backport instances introduced in base-4.18, fix up Down instances

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20230304
 #
-# REGENDATA ("0.14.3",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.15.20230304",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.6.0.20230302
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.6.0.20230302
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.4.4
+            compilerKind: ghc
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -106,18 +116,20 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -135,20 +147,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -177,6 +189,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -200,7 +224,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -230,6 +254,9 @@ jobs:
           package base-orphans
             ghc-options: -Werror
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(base-orphans)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -237,8 +264,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -259,4 +286,10 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,22 @@
+## Changes in 0.9.0 [????.??.??]
+ - Backport new instances from GHC 9.6.1/`base-4.18.0.0`:
+   * `Functor` instances for the `(,,,,) a b c d`, `(,,,,,) a b c d e`, and
+     `(,,,,,) a b c d e f` tuple types.
+   * `Eq` and `Ord` instances for `Generically`
+ - Adapt to recent changes to `Down` instances:
+   * The `Bounded` instance for `Down` was changed in `base-4.15.0.0` to swap
+     the values of `minBound` and `maxBound` for the underlying type. This
+     change has now been propagated to `base-orphans`.
+   * The `Enum` instance for `Down` was removed in `base-4.15.0.0`, but a
+     different version of the instance was added back in `base-4.18.0.0`, where
+     `succ` and `pred` are swapped. We have changed the backported version of
+     this instance in `base-orphans` to match the behavior of the instance
+     added in `base-4.18.0.0`.
+   * The `Integral` instance for `Down` was removed from `base` entirely in
+     `base-4.15.0.0`. We have finally removed it from `base-orphans` in this
+     release, as it actively makes it more difficult to define the
+     aforementioned `Enum` instance.
+
 ## Changes in 0.8.7 [2022.08.11]
  - Backport new instances from GHC 9.2.2/`base-4.16.1.0`:
    * `Ix` instances for various integral types in `Foreign.C.Types`,

--- a/README.markdown
+++ b/README.markdown
@@ -36,7 +36,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `Alternative`, `Eq`, `Ord`, `Read`, `Show`, `Foldable`, and `Traversable` instances for `ZipList`
  * `Applicative` instance for `K1` from `GHC.Generics`
  * `Applicative`, `Bits`, `Bounded`, `Data`, `Enum`, `Eq1`, `FiniteBits`,
-   `Floating`, `Foldable`, `Fractional`, `Functor`, `Integral`, `Ix`, `Ord1`,
+   `Floating`, `Foldable`, `Fractional`, `Functor`, `Ix`, `Ord1`,
    `Monad`, `MonadFix`, `MonadZip`, `Monoid`, `Num`, `Read`, `Read1`, `Real`,
    `RealFloat`, `RealFrac`, `Semigroup`, `Show`, `Show1`, `Storable`, and
    `Traversable` instances for `Down`
@@ -56,12 +56,15 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `Eq` and `Ord` instances for `Control.Exception.ErrorCall`
  * `Eq`, `Ord`, `Read`, and `Show` instances for data types in `GHC.Generics`
  * `Eq`, `Ord`, `Bounded`, `Enum`, and `Ix` instances for `Solo`
+ * `Eq` and `Ord` instances for `Generically1`
  * `Eq1`, `Read1`, and `Show1` instances for `Complex`
  * `Eq1`, `Ord1`, `Read1`, and `Show1` instances for `NonEmpty`
  * `Foldable` instance for `Either`, `(,)` and `Const`
  * `Foldable` and `Traversable` instances for `Alt` from `Data.Monoid`
  * `Functor`, `Applicative`, and `Monad` instances for
    `(,,) a b` and `(,,,) a b c`
+ * `Functor` instances for `(,,,,) a b c d`, `(,,,,,) a b c d e`, and
+    `(,,,,,) a b c d e f`
  * `Functor` instance for `Handler`, `ArgOrder`, `OptDescr`, and `ArgDescr`
  * `Functor`, `Applicative`, `Alternative`, and `MonadPlus` instances for `ArrowMonad`
  * `Functor`, `Applicative`, `Monad`, `Alternative`, and `MonadPlus` instances
@@ -101,6 +104,7 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
 
 ## Supported versions of GHC/`base`
 
+ * `ghc-9.6.*`  / `base-4.18.*`
  * `ghc-9.4.*`  / `base-4.17.*`
  * `ghc-9.2.*`  / `base-4.16.*`
  * `ghc-9.0.*`  / `base-4.15.*`

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2515efda935531123f32b6f6c35f88578595053f291beecef3b862b9c8f71bf7
+-- hash: 7aa19d6f2d3a7409ee405d67a21b8edb902103b703a6f241f2b5e8e219f70a87
 
 name:                base-orphans
 version:             0.9.0
@@ -36,7 +36,7 @@ license:             MIT
 license-file:        LICENSE
 build-type:          Simple
 tested-with:
-    GHC == 7.0.4 , GHC == 7.2.2 , GHC == 7.4.2 , GHC == 7.6.3 , GHC == 7.8.4 , GHC == 7.10.3 , GHC == 8.0.2 , GHC == 8.2.2 , GHC == 8.4.4 , GHC == 8.6.5 , GHC == 8.8.4 , GHC == 8.10.7 , GHC == 9.0.2 , GHC == 9.2.2
+    GHC == 7.0.4 , GHC == 7.2.2 , GHC == 7.4.2 , GHC == 7.6.3 , GHC == 7.8.4 , GHC == 7.10.3 , GHC == 8.0.2 , GHC == 8.2.2 , GHC == 8.4.4 , GHC == 8.6.5 , GHC == 8.8.4 , GHC == 8.10.7 , GHC == 9.0.2 , GHC == 9.2.7 , GHC == 9.4.4 , GHC == 9.6.1
 extra-source-files:
     CHANGES.markdown
     README.markdown

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 72579eb12963b1336e2e979d497378f6dac77805e17a8e53f86b6b2984fcab08
+-- hash: 2515efda935531123f32b6f6c35f88578595053f291beecef3b862b9c8f71bf7
 
 name:                base-orphans
-version:             0.8.7
+version:             0.9.0
 synopsis:            Backwards-compatible orphan instances for base
 description:         @base-orphans@ defines orphan instances that mimic instances available in
                      later versions of @base@ to a wider (older) range of compilers.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: base-orphans
-version: "0.8.7"
+version: "0.9.0"
 synopsis: Backwards-compatible orphan instances for base
 license: MIT
 author:

--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,9 @@ tested-with:   GHC == 7.0.4
              , GHC == 8.8.4
              , GHC == 8.10.7
              , GHC == 9.0.2
-             , GHC == 9.2.2
+             , GHC == 9.2.7
+             , GHC == 9.4.4
+             , GHC == 9.6.1
 
 extra-source-files:
   - CHANGES.markdown

--- a/src/Data/Orphans/Prelude.hs
+++ b/src/Data/Orphans/Prelude.hs
@@ -21,7 +21,7 @@ This makes it much easier to be -Wall-compliant.
 Note that this module does not export any modules that could introduce name clashes.
 -}
 module Data.Orphans.Prelude
-#if MIN_VERSION_base(4,16,1)
+#if MIN_VERSION_base(4,18,0)
     () where
 #else
     ( module OrphansPrelude
@@ -157,6 +157,11 @@ import Data.Semigroup as OrphansPrelude (Semigroup(..))
 import Data.Typeable ( Typeable1, Typeable2, Typeable3, Typeable4
                      , Typeable5, Typeable6, Typeable7 )
 # endif
+
+# if MIN_VERSION_base(4,17,0) && !(MIN_VERSION_base(4,18,0))
+import GHC.Generics as OrphansPrelude ( Generic(..), Generic1(..)
+                                      , Generically(..), Generically1(..) )
+#endif
 
 # if MIN_VERSION_base(4,4,0)
 realPart, imagPart :: Complex a -> a


### PR DESCRIPTION
The trickiest part was the `Down` instances, as:

* The `Bounded` and `Enum` instances have had their implementations change in `base` in the meantime.
* The `Integral` instance for `Down` has been removed entirely from `base`, and the vestigial `Integral` instance in `base-orphans` (which I had neglected to remove in the interim) now does not mix well with the new instance context for the `Enum` instance.

  As a result, I decided to rip off the bandage and remove the `Integral` instance from `base-orphans` as well. This requires a major version bump.

Fixes #64.