### PR TITLE
Drop support for pre-8.0 versions of GHC

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240416
+# version: 0.19.20241021
 #
-# REGENDATA ("0.19.20240416",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20241021",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,14 +23,14 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.10.0.20240413
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.10.0.20240413
+            compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.2
@@ -38,9 +38,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.6.6
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -66,81 +66,40 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.2.2
-            compilerKind: ghc
-            compilerVersion: 7.2.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.0.4
-            compilerKind: ghc
-            compilerVersion: 7.0.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -152,27 +111,18 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -201,18 +151,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -236,7 +174,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -266,10 +204,7 @@ jobs:
           package base-orphans
             ghc-options: -Werror
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(base-orphans)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(base-orphans)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -277,7 +212,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -300,7 +235,7 @@ jobs:
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in next [????.??.??]
+ - Drop support for pre-8.0 versions of GHC.
+
 ## Changes in 0.9.2 [2024.04.30]
  - Backport new instances from GHC 9.10/`base-4.20`:
    * `Fractional`, `RealFrac`, `Floating`, and `RealFloat` instances for `Compose`

--- a/README.markdown
+++ b/README.markdown
@@ -118,12 +118,6 @@ To use `base-orphans`, simply `import Data.Orphans ()`.
  * `ghc-8.4.*`  / `base-4.11.*`
  * `ghc-8.2.*`  / `base-4.10.*`
  * `ghc-8.0.*`  / `base-4.9.*`
- * `ghc-7.10.*` / `base-4.8.*`
- * `ghc-7.8.*`  / `base-4.7.*`
- * `ghc-7.6.*`  / `base-4.6.*`
- * `ghc-7.4.*`  / `base-4.5.*`
- * `ghc-7.2.*`  / `base-4.4.*`
- * `ghc-7.0.*`  / `base-4.3.*`
 
 We also make an attempt to keep `base-orphans` building with GHC HEAD, but due
 to its volatility, it may not work at any given point in time. If it doesn't,

--- a/base-orphans.cabal
+++ b/base-orphans.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0c23e2cb85ef24758da1fa779ef857dc3889dfc4238a4057841a071b38ce3e96
+-- hash: e780edc5dc880fffe83b74901fddf088070190f9ad366383292cb74d36ae668f
 
 name:                base-orphans
 version:             0.9.2
@@ -36,7 +36,7 @@ license:             MIT
 license-file:        LICENSE
 build-type:          Simple
 tested-with:
-    GHC == 7.0.4 , GHC == 7.2.2 , GHC == 7.4.2 , GHC == 7.6.3 , GHC == 7.8.4 , GHC == 7.10.3 , GHC == 8.0.2 , GHC == 8.2.2 , GHC == 8.4.4 , GHC == 8.6.5 , GHC == 8.8.4 , GHC == 8.10.7 , GHC == 9.0.2 , GHC == 9.2.8 , GHC == 9.4.8 , GHC == 9.6.5 , GHC == 9.8.2 , GHC == 9.10.1
+    GHC == 8.0.2 , GHC == 8.2.2 , GHC == 8.4.4 , GHC == 8.6.5 , GHC == 8.8.4 , GHC == 8.10.7 , GHC == 9.0.2 , GHC == 9.2.8 , GHC == 9.4.8 , GHC == 9.6.6 , GHC == 9.8.2 , GHC == 9.10.1
 extra-source-files:
     CHANGES.markdown
     README.markdown
@@ -50,7 +50,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.3 && <5
+      base >=4.9 && <5
     , ghc-prim
   exposed-modules:
       Data.Orphans
@@ -66,7 +66,7 @@ test-suite spec
   ghc-options: -Wall
   build-depends:
       QuickCheck
-    , base >=4.3 && <5
+    , base >=4.9 && <5
     , base-orphans
     , hspec ==2.*
   build-tool-depends: hspec-discover:hspec-discover == 2.*

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,4 +1,4 @@
-distribution:           bionic
+distribution:           jammy
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror

--- a/package.yaml
+++ b/package.yaml
@@ -27,13 +27,7 @@ description: |
   See also the
   <https://github.com/haskell-compat/base-orphans#what-is-not-covered what is not covered>
   section.
-tested-with:   GHC == 7.0.4
-             , GHC == 7.2.2
-             , GHC == 7.4.2
-             , GHC == 7.6.3
-             , GHC == 7.8.4
-             , GHC == 7.10.3
-             , GHC == 8.0.2
+tested-with:   GHC == 8.0.2
              , GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.5
@@ -42,7 +36,7 @@ tested-with:   GHC == 7.0.4
              , GHC == 9.0.2
              , GHC == 9.2.8
              , GHC == 9.4.8
-             , GHC == 9.6.5
+             , GHC == 9.6.6
              , GHC == 9.8.2
              , GHC == 9.10.1
 
@@ -55,7 +49,7 @@ github: haskell-compat/base-orphans
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.3 && < 5
+  - base >= 4.9 && < 5
 
 library:
   source-dirs: src

--- a/src/Data/Orphans.hs
+++ b/src/Data/Orphans.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -7,57 +8,35 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-#if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 706
-{-# LANGUAGE PolyKinds #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE DataKinds #-}
-# if __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE NullaryTypeClasses #-}
-# endif
-#endif
-
-#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 806
+#if __GLASGOW_HASKELL__ < 806
 {-# LANGUAGE TypeInType #-}
 #endif
 
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 {-|
 Exports orphan instances that mimic instances available in later versions of @base@.
 To use them, simply @import Data.Orphans ()@.
 -}
 module Data.Orphans () where
 
-#if __GLASGOW_HASKELL__ >= 701 && !(MIN_VERSION_base(4,12,0))
+#if !(MIN_VERSION_base(4,12,0))
 import           GHC.Generics as Generics hiding (prec)
 #endif
 
-#if !(MIN_VERSION_base(4,6,0))
-import           Control.Monad.Instances ()
-#endif
-
-#if !(MIN_VERSION_base(4,9,0))
-import qualified Data.Monoid as Monoid
-import           Text.ParserCombinators.ReadPrec as ReadPrec
-#endif
-
-#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+#if !(MIN_VERSION_base(4,11,0))
 import qualified Control.Monad.Fail as Fail (MonadFail(..))
 #endif
 
-#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,16,0))
+#if !(MIN_VERSION_base(4,16,0))
 import qualified Data.Functor.Product as Functor
 #endif
 
@@ -82,18 +61,6 @@ import qualified Data.Traversable as T (Traversable(..))
 import           GHC.Tuple (Solo(..))
 #endif
 
-#if __GLASGOW_HASKELL__ < 710
-import           Control.Exception as Exception
-import           Control.Monad.ST.Lazy as Lazy
-import           GHC.Exts as Exts
-import           GHC.IO.Exception as Exception
-import           Text.ParserCombinators.ReadP as ReadP
-
-# if defined(mingw32_HOST_OS)
-import           GHC.ConsoleHandler as Console
-# endif
-#endif
-
 #if !(MIN_VERSION_base(4,20,0))
 import           Data.Orphans.Prelude
 #endif
@@ -102,846 +69,9 @@ import           Data.Orphans.Prelude
 
 -------------------------------------------------------------------------------
 
-#if MIN_VERSION_base(4,4,0) && !(MIN_VERSION_base(4,7,0))
-instance Show Fingerprint where
-    show (Fingerprint w1 w2) = hex16 w1 ++ hex16 w2
-      where
-        -- Formats a 64 bit number as 16 digits hex.
-        hex16 :: Word64 -> String
-        hex16 i = let hex = showHex i ""
-                   in replicate (16 - length hex) '0' ++ hex
-#endif
-
-#if !(MIN_VERSION_base(4,4,0))
-instance HasResolution a => Read (Fixed a) where
-    readsPrec _ = readsFixed
-
-readsFixed :: (HasResolution a) => ReadS (Fixed a)
-readsFixed = readsSigned
-    where readsSigned ('-' : xs) = [ (negate x, rest)
-                                   | (x, rest) <- readsUnsigned xs ]
-          readsSigned xs = readsUnsigned xs
-          readsUnsigned xs = case span isDigit xs of
-                             ([], _) -> []
-                             (is, xs') ->
-                                 let i = fromInteger (read is)
-                                 in case xs' of
-                                    '.' : xs'' ->
-                                        case span isDigit xs'' of
-                                        ([], _) -> []
-                                        (js, xs''') ->
-                                            let j = fromInteger (read js)
-                                                l = genericLength js :: Integer
-                                            in [(i + (j / (10 ^ l)), xs''')]
-                                    _ -> [(i, xs')]
-
-deriving instance Typeable1 SampleVar
-
-instance Applicative (Strict.ST s) where
-    pure  = return
-    (<*>) = ap
-
-instance Applicative (Lazy.ST s) where
-    pure  = return
-    (<*>) = ap
-
-instance Ord TyCon where
-  compare x y = compare (tyConString x) (tyConString y)
-
--- http://hackage.haskell.org/package/base-4.3.0.0/docs/Data-Typeable.html#t:TypeRep
--- Notice that the `TypeRep` constructor is not exported
--- and no pure accessor to its `Key` field is provided.
-instance Ord TypeRep where
-  compare x y =
-    compare (typeRepTyCon x) (typeRepTyCon x) `mappend`
-    compare (typeRepArgs x) (typeRepArgs y)
-#endif
-
--- These instances are only valid if Bits isn't a subclass of Num (as Bool is
--- not a Num instance), which is only true as of base-4.6.0.0 and later.
-#if MIN_VERSION_base(4,6,0) && !(MIN_VERSION_base(4,7,0))
-instance Bits Bool where
-    (.&.) = (&&)
-
-    (.|.) = (||)
-
-    xor = (/=)
-
-    complement = not
-
-    shift x 0 = x
-    shift _ _ = False
-
-    rotate x _ = x
-
-    bit 0 = True
-    bit _ = False
-
-    testBit x 0 = x
-    testBit _ _ = False
-
-    bitSize _ = 1
-
-    isSigned _ = False
-
-    popCount False = 0
-    popCount True  = 1
-#endif
-
-#if !(MIN_VERSION_base(4,6,0))
-# if defined(HTYPE_DEV_T)
-#  if MIN_VERSION_base(4,5,0)
-deriving instance Bits CDev
-deriving instance Bounded CDev
-deriving instance Integral CDev
-#  else
-type HDev = HTYPE_DEV_T
-
-instance Bits CDev where
-    (.&.)         = unsafeCoerce ((.&.)         :: HDev -> HDev -> HDev)
-    (.|.)         = unsafeCoerce ((.|.)         :: HDev -> HDev -> HDev)
-    xor           = unsafeCoerce (xor           :: HDev -> HDev -> HDev)
-    shift         = unsafeCoerce (shift         :: HDev -> Int  -> HDev)
-    rotate        = unsafeCoerce (rotate        :: HDev -> Int  -> HDev)
-    setBit        = unsafeCoerce (setBit        :: HDev -> Int  -> HDev)
-    clearBit      = unsafeCoerce (clearBit      :: HDev -> Int  -> HDev)
-    complementBit = unsafeCoerce (complementBit :: HDev -> Int  -> HDev)
-    testBit       = unsafeCoerce (testBit       :: HDev -> Int  -> Bool)
-    complement    = unsafeCoerce (complement    :: HDev -> HDev)
-    bit           = unsafeCoerce (bit           :: Int  -> HDev)
-    bitSize       = unsafeCoerce (bitSize       :: HDev -> Int)
-    isSigned      = unsafeCoerce (isSigned      :: HDev -> Bool)
-
-instance Bounded CDev where
-    minBound = unsafeCoerce (minBound :: HDev)
-    maxBound = unsafeCoerce (maxBound :: HDev)
-
-instance Integral CDev where
-    quot      = unsafeCoerce (quot      :: HDev -> HDev -> HDev)
-    rem       = unsafeCoerce (rem       :: HDev -> HDev -> HDev)
-    div       = unsafeCoerce (div       :: HDev -> HDev -> HDev)
-    mod       = unsafeCoerce (mod       :: HDev -> HDev -> HDev)
-    quotRem   = unsafeCoerce (quotRem   :: HDev -> HDev -> (HDev, HDev))
-    divMod    = unsafeCoerce (divMod    :: HDev -> HDev -> (HDev, HDev))
-    toInteger = unsafeCoerce (toInteger :: HDev -> Integer)
-#  endif
-# endif
-
-instance Applicative ReadP where
-    pure  = return
-    (<*>) = ap
-
-instance Alternative ReadP where
-    empty = mzero
-    (<|>) = mplus
-
-instance Applicative ReadPrec where
-    pure  = return
-    (<*>) = ap
-
-instance Alternative ReadPrec where
-    empty = mzero
-    (<|>) = mplus
-
-instance Functor Exception.Handler where
-     fmap f (Exception.Handler h) = Exception.Handler (fmap f . h)
-
-instance
-# if MIN_VERSION_base(4,4,0)
-  Arrow a
-# else
-  ArrowApply a
-# endif
-  => Functor (ArrowMonad a) where
-    fmap f (ArrowMonad m) = ArrowMonad $ m >>> arr f
-
-instance
-# if MIN_VERSION_base(4,4,0)
-  Arrow a
-# else
-  ArrowApply a
-# endif
-  => Applicative (ArrowMonad a) where
-   pure x = ArrowMonad (arr (const x))
-   ArrowMonad f <*> ArrowMonad x = ArrowMonad (f &&& x >>> arr (uncurry id))
-
-instance
-# if MIN_VERSION_base(4,4,0)
-  ArrowPlus a
-# else
-  (ArrowApply a, ArrowPlus a)
-# endif
-  => Alternative (ArrowMonad a) where
-   empty = ArrowMonad zeroArrow
-   ArrowMonad x <|> ArrowMonad y = ArrowMonad (x <+> y)
-
-instance (ArrowApply a, ArrowPlus a) => MonadPlus (ArrowMonad a) where
-   mzero = ArrowMonad zeroArrow
-   ArrowMonad x `mplus` ArrowMonad y = ArrowMonad (x <+> y)
-#endif
-
-#if !(MIN_VERSION_base(4,7,0))
-deriving instance F.Foldable (Const m)
-deriving instance F.Foldable (Either a)
-deriving instance T.Traversable (Const m)
-deriving instance T.Traversable (Either a)
-
-instance F.Foldable ((,) a) where
-    foldMap f (_, y) = f y
-
-    foldr f z (_, y) = f y z
-
-instance T.Traversable ((,) a) where
-    traverse f (x, y) = (,) x <$> f y
-
-deriving instance Monoid a => Monoid (Const a b)
-deriving instance Read a => Read (Down a)
-deriving instance Show a => Show (Down a)
-deriving instance Eq ErrorCall
-deriving instance Ord ErrorCall
-deriving instance Num a => Num (Sum a)
-deriving instance Num a => Num (Product a)
-deriving instance Data Version
--- GHC Trac #8218
-deriving instance Monad m => Monad (WrappedMonad m)
-deriving instance Eq a => Eq (ZipList a)
-deriving instance Ord a => Ord (ZipList a)
-deriving instance Read a => Read (ZipList a)
-deriving instance Show a => Show (ZipList a)
-deriving instance Functor ArgOrder
-deriving instance Functor OptDescr
-deriving instance Functor ArgDescr
-#endif
-
-#if __GLASGOW_HASKELL__ >= 701 && !(MIN_VERSION_base(4,7,0))
-deriving instance Eq (U1 p)
-deriving instance Ord (U1 p)
-deriving instance Read (U1 p)
-deriving instance Show (U1 p)
-
-deriving instance Eq p => Eq (Par1 p)
-deriving instance Ord p => Ord (Par1 p)
-deriving instance Read p => Read (Par1 p)
-deriving instance Show p => Show (Par1 p)
-
-deriving instance Eq (f p) => Eq (Rec1 f p)
-deriving instance Ord (f p) => Ord (Rec1 f p)
-deriving instance Read (f p) => Read (Rec1 f p)
-deriving instance Show (f p) => Show (Rec1 f p)
-
-deriving instance Eq c => Eq (K1 i c p)
-deriving instance Ord c => Ord (K1 i c p)
-deriving instance Read c => Read (K1 i c p)
-deriving instance Show c => Show (K1 i c p)
-
-deriving instance Eq (f p) => Eq (M1 i c f p)
-deriving instance Ord (f p) => Ord (M1 i c f p)
-deriving instance Read (f p) => Read (M1 i c f p)
-deriving instance Show (f p) => Show (M1 i c f p)
-
-deriving instance (Eq (f p), Eq (g p)) => Eq ((f :+: g) p)
-deriving instance (Ord (f p), Ord (g p)) => Ord ((f :+: g) p)
-deriving instance (Read (f p), Read (g p)) => Read ((f :+: g) p)
-deriving instance (Show (f p), Show (g p)) => Show ((f :+: g) p)
-
-deriving instance (Eq (f p), Eq (g p)) => Eq ((f :*: g) p)
-deriving instance (Ord (f p), Ord (g p)) => Ord ((f :*: g) p)
--- Due to a GHC bug (https://ghc.haskell.org/trac/ghc/ticket/9830), the derived
--- Read and Show instances for infix data constructors will use the wrong
--- precedence (prior to GHC 7.10).
--- We'll manually derive Read :*: and Show :*: instances to avoid this.
-instance (Read (f p), Read (g p)) => Read ((f :*: g) p) where
-    readPrec = parens . ReadPrec.prec 6 $ do
-        fp <- ReadPrec.step readPrec
-        Symbol ":*:" <- lexP
-        gp <- ReadPrec.step readPrec
-        return $ fp :*: gp
-    readListPrec = readListPrecDefault
-instance (Show (f p), Show (g p)) => Show ((f :*: g) p) where
-     showsPrec p (l :*: r) = showParen (p > sixPrec) $
-            showsPrec (sixPrec + 1) l
-         . showString " :*: "
-         . showsPrec (sixPrec + 1) r
-       where sixPrec = 6
-
-deriving instance Eq (f (g p)) => Eq ((f :.: g) p)
-deriving instance Ord (f (g p)) => Ord ((f :.: g) p)
-deriving instance Read (f (g p)) => Read ((f :.: g) p)
-deriving instance Show (f (g p)) => Show ((f :.: g) p)
-#endif
-
-#if MIN_VERSION_base(4,7,0) && !(MIN_VERSION_base(4,8,0))
--- | Construct tag-less 'Version'
---
--- /Since: 4.8.0.0/
-makeVersion :: [Int] -> Version
-makeVersion b = Version b []
-
--- | /Since: 4.8.0.0/
-instance IsList Version where
-  type (Item Version) = Int
-  fromList = makeVersion
-  toList = versionBranch
-#endif
-
-#if !(MIN_VERSION_base(4,8,0))
-deriving instance Eq a => Eq (Const a b)
-deriving instance Ord a => Ord (Const a b)
-
-instance Read a => Read (Const a b) where
-    readsPrec d = readParen (d > 10)
-        $ \r -> [(Const x,t) | ("Const", s) <- lex r, (x, t) <- readsPrec 11 s]
-
-instance Show a => Show (Const a b) where
-    showsPrec d (Const x) = showParen (d > 10) $
-                            showString "Const " . showsPrec 11 x
-
-deriving instance Functor First
-deriving instance Applicative First
-deriving instance Monad First
-deriving instance Functor Last
-deriving instance Applicative Last
-deriving instance Monad Last
-
--- In base-4.3 and earlier, pattern matching on a Complex value invokes a
--- RealFloat constraint due to the use of the DatatypeContexts extension.
-# if MIN_VERSION_base(4,4,0)
-instance Storable a
-# else
-instance (Storable a, RealFloat a)
-# endif
-  => Storable (Complex a) where
-    sizeOf a       = 2 * sizeOf (realPart a)
-    alignment a    = alignment (realPart a)
-    peek p           = do
-                        q <- return $ castPtr p
-                        r <- peek q
-                        i <- peekElemOff q 1
-                        return (r :+ i)
-    poke p (r :+ i)  = do
-                        q <-return $  (castPtr p)
-                        poke q r
-                        pokeElemOff q 1 i
-
-instance (Storable a, Integral a) => Storable (Ratio a) where
-    sizeOf _    = 2 * sizeOf (undefined :: a)
-    alignment _ = alignment (undefined :: a )
-    peek p           = do
-                        q <- return $ castPtr p
-                        r <- peek q
-                        i <- peekElemOff q 1
-                        return (r % i)
-    poke p (r :% i)  = do
-                        q <-return $  (castPtr p)
-                        poke q r
-                        pokeElemOff q 1 i
-#endif
-
-#if !(MIN_VERSION_base(4,9,0))
-instance Storable () where
-  sizeOf _ = 0
-  alignment _ = 1
-  peek _ = return ()
-  poke _ _ = return ()
-
-deriving instance Bits a       => Bits (Const a b)
-deriving instance Bounded a    => Bounded (Const a b)
-deriving instance Enum a       => Enum (Const a b)
-deriving instance Floating a   => Floating (Const a b)
-deriving instance Fractional a => Fractional (Const a b)
-deriving instance Integral a   => Integral (Const a b)
-deriving instance IsString a   => IsString (Const a b)
-deriving instance Ix a         => Ix (Const a b)
-deriving instance Num a        => Num (Const a b)
-deriving instance Real a       => Real (Const a b)
-deriving instance RealFloat a  => RealFloat (Const a b)
-deriving instance RealFrac a   => RealFrac (Const a b)
-deriving instance Storable a   => Storable (Const a b)
-
-deriving instance           Data All
-deriving instance           Data Monoid.Any
-deriving instance Data a => Data (Dual a)
-deriving instance Data a => Data (First a)
-deriving instance Data a => Data (Last a)
-deriving instance Data a => Data (Product a)
-deriving instance Data a => Data (Sum a)
-
-instance F.Foldable Dual where
-    foldMap            = coerce
-
-    foldl              = coerce
-    foldl1 _           = getDual
-    foldr f z (Dual x) = f x z
-    foldr1 _           = getDual
-# if MIN_VERSION_base(4,6,0)
-    foldl'             = coerce
-    foldr'             = F.foldr
-# endif
-# if MIN_VERSION_base(4,8,0)
-    elem               = (. getDual) #. (==)
-    length _           = 1
-    maximum            = getDual
-    minimum            = getDual
-    null _             = False
-    product            = getDual
-    sum                = getDual
-    toList (Dual x)    = [x]
-# endif
-
-instance F.Foldable Sum where
-    foldMap            = coerce
-
-    foldl              = coerce
-    foldl1 _           = getSum
-    foldr f z (Sum x)  = f x z
-    foldr1 _           = getSum
-# if MIN_VERSION_base(4,6,0)
-    foldl'                = coerce
-    foldr'                = F.foldr
-# endif
-# if MIN_VERSION_base(4,8,0)
-    elem               = (. getSum) #. (==)
-    length _           = 1
-    maximum            = getSum
-    minimum            = getSum
-    null _             = False
-    product            = getSum
-    sum                = getSum
-    toList (Sum x)     = [x]
-# endif
-
-instance F.Foldable Product where
-    foldMap               = coerce
-
-    foldl                 = coerce
-    foldl1 _              = getProduct
-    foldr f z (Product x) = f x z
-    foldr1 _              = getProduct
-# if MIN_VERSION_base(4,6,0)
-    foldl'                = coerce
-    foldr'                = F.foldr
-# endif
-# if MIN_VERSION_base(4,8,0)
-    elem                  = (. getProduct) #. (==)
-    length _              = 1
-    maximum               = getProduct
-    minimum               = getProduct
-    null _                = False
-    product               = getProduct
-    sum                   = getProduct
-    toList (Product x)    = [x]
-# endif
-
-# if MIN_VERSION_base(4,8,0)
-(#.)   :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
-(#.) _f = coerce
-# endif
-
-# if !(MIN_VERSION_base(4,7,0))
-coerce ::                  a -> b
-coerce = unsafeCoerce
-# endif
-
-instance Functor Dual where
-    fmap     = coerce
-
-instance Applicative Dual where
-    pure     = Dual
-    (<*>)    = coerce
-
-instance Monad Dual where
-    return   = Dual
-    m >>= k  = k (getDual m)
-
-instance Functor Sum where
-    fmap     = coerce
-
-instance Applicative Sum where
-    pure     = Sum
-    (<*>)    = coerce
-
-instance Monad Sum where
-    return   = Sum
-    m >>= k  = k (getSum m)
-
-instance Functor Product where
-    fmap     = coerce
-
-instance Applicative Product where
-    pure     = Product
-    (<*>)    = coerce
-
-instance Monad Product where
-    return   = Product
-    m >>= k  = k (getProduct m)
-
-instance F.Foldable First where
-    foldMap f = F.foldMap f . getFirst
-
-instance F.Foldable Last where
-    foldMap f = F.foldMap f . getLast
-
-instance Monoid a => Monoid (IO a) where
-    mempty = pure mempty
-    mappend = liftA2 mappend
-
--- see: #10190 https://git.haskell.org/ghc.git/commitdiff/9db005a444722e31aca1956b058e069bcf3cacbd
-instance Monoid a => Monad ((,) a) where
-    return x = (mempty, x)
-    (u, a) >>= k = case k a of (v, b) -> (u `mappend` v, b)
-
-instance MonadFix Dual where
-    mfix f   = Dual (fix (getDual . f))
-
-instance MonadFix Sum where
-    mfix f   = Sum (fix (getSum . f))
-
-instance MonadFix Product where
-    mfix f   = Product (fix (getProduct . f))
-
-instance MonadFix First where
-    mfix f   = First (mfix (getFirst . f))
-
-instance MonadFix Last where
-    mfix f   = Last (mfix (getLast . f))
-
-instance T.Traversable Dual where
-    traverse f (Dual x) = Dual <$> f x
-
-instance T.Traversable Sum where
-    traverse f (Sum x) = Sum <$> f x
-
-instance T.Traversable Product where
-    traverse f (Product x) = Product <$> f x
-
-instance T.Traversable First where
-    traverse f (First x) = First <$> T.traverse f x
-
-instance T.Traversable Last where
-    traverse f (Last x) = Last <$> T.traverse f x
-
-deriving instance F.Foldable    ZipList
-deriving instance T.Traversable ZipList
-
-# if MIN_VERSION_base(4,4,0)
-deriving instance Functor     Complex
-deriving instance F.Foldable    Complex
-deriving instance T.Traversable Complex
-
-instance Applicative Complex where
-  pure a = a :+ a
-  f :+ g <*> a :+ b = f a :+ g b
-
-instance Monad Complex where
-  return a = a :+ a
-  a :+ b >>= f = realPart (f a) :+ imagPart (f b)
-
-instance MonadZip Dual where
-    -- Cannot use coerce, it's unsafe
-    mzipWith = liftM2
-
-instance MonadZip Sum where
-    mzipWith = liftM2
-
-instance MonadZip Product where
-    mzipWith = liftM2
-
-instance MonadZip Maybe where
-    mzipWith = liftM2
-
-instance MonadZip First where
-    mzipWith = liftM2
-
-instance MonadZip Last where
-    mzipWith = liftM2
-# endif
-
-# if MIN_VERSION_base(4,7,0)
-instance Alternative Proxy where
-    empty = Proxy
-    {-# INLINE empty #-}
-    _ <|> _ = Proxy
-    {-# INLINE (<|>) #-}
-
-instance MonadPlus Proxy where
-#  if !(MIN_VERSION_base(4,8,0))
-    mzero = Proxy
-    {-# INLINE mzero #-}
-    mplus _ _ = Proxy
-    {-# INLINE mplus #-}
-#  endif
-
-instance MonadZip Proxy where
-    mzipWith _ _ _ = Proxy
-    {-# INLINE mzipWith #-}
-
-deriving instance FiniteBits a => FiniteBits (Const a b)
-# endif
-
-# if MIN_VERSION_base(4,8,0)
-deriving instance (Data (f a), Typeable f, Typeable a)
-    => Data (Alt (f :: * -> *) (a :: *))
-
-instance MonadFix f => MonadFix (Alt f) where
-    mfix f   = Alt (mfix (getAlt . f))
-
-instance MonadZip f => MonadZip (Alt f) where
-    mzipWith f (Alt ma) (Alt mb) = Alt (mzipWith f ma mb)
-
-deriving instance Bits a       => Bits (Identity a)
-deriving instance Bounded a    => Bounded (Identity a)
-deriving instance Enum a       => Enum (Identity a)
-deriving instance FiniteBits a => FiniteBits (Identity a)
-deriving instance Floating a   => Floating (Identity a)
-deriving instance Fractional a => Fractional (Identity a)
-deriving instance Integral a   => Integral (Identity a)
-deriving instance IsString a   => IsString (Identity a)
-deriving instance Ix a         => Ix (Identity a)
-deriving instance Monoid a     => Monoid (Identity a)
-deriving instance Num a        => Num (Identity a)
-deriving instance Real a       => Real (Identity a)
-deriving instance RealFloat a  => RealFloat (Identity a)
-deriving instance RealFrac a   => RealFrac (Identity a)
-deriving instance Storable a   => Storable (Identity a)
-# endif
-
-# if __GLASGOW_HASKELL__ >= 701
-deriving instance Data p => Data (V1 p)
-deriving instance Data p => Data (U1 p)
-deriving instance Data p => Data (Par1 p)
-deriving instance (Typeable i, Data p, Data c) => Data (K1 i c p)
-deriving instance Data Generics.Fixity
-deriving instance Data Associativity
-
-deriving instance                                 F.Foldable V1
-deriving instance                                 F.Foldable Par1
-deriving instance F.Foldable f                 => F.Foldable (Rec1 f)
-deriving instance                                 F.Foldable (K1 i c)
-deriving instance F.Foldable f                 => F.Foldable (M1 i c f)
-deriving instance (F.Foldable f, F.Foldable g) => F.Foldable (f :+: g)
-deriving instance (F.Foldable f, F.Foldable g) => F.Foldable (f :*: g)
-deriving instance (F.Foldable f, F.Foldable g) => F.Foldable (f :.: g)
-
-deriving instance                           Functor V1
-deriving instance                           Functor Par1
-deriving instance Functor f              => Functor (Rec1 f)
-deriving instance                           Functor (K1 i c)
-deriving instance Functor f              => Functor (M1 i c f)
-deriving instance (Functor f, Functor g) => Functor (f :+: g)
-deriving instance (Functor f, Functor g) => Functor (f :*: g)
-deriving instance (Functor f, Functor g) => Functor (f :.: g)
-
-instance MonadFix Par1 where
-    mfix f = Par1 (fix (unPar1 . f))
-
-instance MonadFix f => MonadFix (Rec1 f) where
-    mfix f = Rec1 (mfix (unRec1 . f))
-
-instance MonadFix f => MonadFix (M1 i c f) where
-    mfix f = M1 (mfix (unM1. f))
-
-instance (MonadFix f, MonadFix g) => MonadFix (f :*: g) where
-    mfix f = (mfix (fstP . f)) :*: (mfix (sndP . f))
-      where
-        fstP (a :*: _) = a
-        sndP (_ :*: b) = b
-
-instance MonadZip U1 where
-    mzipWith _ _ _ = U1
-
-instance MonadZip Par1 where
-    mzipWith = liftM2
-
-instance MonadZip f => MonadZip (Rec1 f) where
-    mzipWith f (Rec1 fa) (Rec1 fb) = Rec1 (mzipWith f fa fb)
-
-instance MonadZip f => MonadZip (M1 i c f) where
-    mzipWith f (M1 fa) (M1 fb) = M1 (mzipWith f fa fb)
-
-instance (MonadZip f, MonadZip g) => MonadZip (f :*: g) where
-    mzipWith f (x1 :*: y1) (x2 :*: y2) = mzipWith f x1 x2 :*: mzipWith f y1 y2
-
-deriving instance                                       T.Traversable V1
-deriving instance                                       T.Traversable Par1
-deriving instance T.Traversable f                    => T.Traversable (Rec1 f)
-deriving instance                                       T.Traversable (K1 i c)
-deriving instance T.Traversable f                    => T.Traversable (M1 i c f)
-deriving instance (T.Traversable f, T.Traversable g) => T.Traversable (f :+: g)
-deriving instance (T.Traversable f, T.Traversable g) => T.Traversable (f :*: g)
-deriving instance (T.Traversable f, T.Traversable g) => T.Traversable (f :.: g)
-
-deriving instance Bounded Associativity
-deriving instance Enum    Associativity
-deriving instance Ix      Associativity
-
-deriving instance Eq   (V1 p)
-deriving instance Ord  (V1 p)
--- Implement Read instance manually to get around an old GHC bug
--- (Trac #7931)
-instance Read (V1 p) where
-    readPrec     = parens ReadPrec.pfail
-    readList     = readListDefault
-    readListPrec = readListPrecDefault
-deriving instance Show (V1 p)
-
-instance Functor U1 where
-  fmap _ _ = U1
-
-instance Applicative U1 where
-  pure _ = U1
-  _ <*> _ = U1
-
-instance Alternative U1 where
-  empty = U1
-  _ <|> _ = U1
-
-instance Monad U1 where
-#  if !(MIN_VERSION_base(4,8,0))
-  return _ = U1
-#  endif
-  _ >>= _ = U1
-
-instance MonadPlus U1 where
-#  if !(MIN_VERSION_base(4,8,0))
-  mzero = U1
-  mplus _ _ = U1
-#  endif
-
-instance F.Foldable U1 where
-    foldMap _ _ = mempty
-    {-# INLINE foldMap #-}
-    fold _ = mempty
-    {-# INLINE fold #-}
-    foldr _ z _ = z
-    {-# INLINE foldr #-}
-    foldl _ z _ = z
-    {-# INLINE foldl #-}
-    foldl1 _ _ = error "foldl1: U1"
-    foldr1 _ _ = error "foldr1: U1"
-#  if MIN_VERSION_base(4,8,0)
-    length _   = 0
-    null _     = True
-    elem _ _   = False
-    sum _      = 0
-    product _  = 1
-#  endif
-
-instance T.Traversable U1 where
-    traverse _ _ = pure U1
-    {-# INLINE traverse #-}
-    sequenceA _ = pure U1
-    {-# INLINE sequenceA #-}
-    mapM _ _ = return U1
-    {-# INLINE mapM #-}
-    sequence _ = return U1
-    {-# INLINE sequence #-}
-
-instance Applicative Par1 where
-  pure a = Par1 a
-  Par1 f <*> Par1 x = Par1 (f x)
-
-instance Monad Par1 where
-#  if !(MIN_VERSION_base(4,8,0))
-  return a = Par1 a
-#  endif
-  Par1 x >>= f = f x
-
-instance Applicative f => Applicative (Rec1 f) where
-  pure a = Rec1 (pure a)
-  Rec1 f <*> Rec1 x = Rec1 (f <*> x)
-
-instance Alternative f => Alternative (Rec1 f) where
-  empty = Rec1 empty
-  Rec1 l <|> Rec1 r = Rec1 (l <|> r)
-
-instance Monad f => Monad (Rec1 f) where
-#  if !(MIN_VERSION_base(4,8,0))
-  return a = Rec1 (return a)
-#  endif
-  Rec1 x >>= f = Rec1 (x >>= \a -> unRec1 (f a))
-
-instance MonadPlus f => MonadPlus (Rec1 f) where
-#  if !(MIN_VERSION_base(4,8,0))
-  mzero = Rec1 mzero
-  mplus (Rec1 a) (Rec1 b) = Rec1 (mplus a b)
-#  endif
-
-instance Applicative f => Applicative (M1 i c f) where
-  pure a = M1 (pure a)
-  M1 f <*> M1 x = M1 (f <*> x)
-
-instance Alternative f => Alternative (M1 i c f) where
-  empty = M1 empty
-  M1 l <|> M1 r = M1 (l <|> r)
-
-instance Monad f => Monad (M1 i c f) where
-#  if !(MIN_VERSION_base(4,8,0))
-  return a = M1 (return a)
-#  endif
-  M1 x >>= f = M1 (x >>= \a -> unM1 (f a))
-
-instance MonadPlus f => MonadPlus (M1 i c f) where
-#  if !(MIN_VERSION_base(4,8,0))
-  mzero = M1 mzero
-  mplus (M1 a) (M1 b) = M1 (mplus a b)
-#  endif
-
-instance (Applicative f, Applicative g) => Applicative (f :*: g) where
-  pure a = pure a :*: pure a
-  (f :*: g) <*> (x :*: y) = (f <*> x) :*: (g <*> y)
-
-instance (Alternative f, Alternative g) => Alternative (f :*: g) where
-  empty = empty :*: empty
-  (x1 :*: y1) <|> (x2 :*: y2) = (x1 <|> x2) :*: (y1 <|> y2)
-
-instance (Monad f, Monad g) => Monad (f :*: g) where
-#  if !(MIN_VERSION_base(4,8,0))
-  return a = return a :*: return a
-#  endif
-  (m :*: n) >>= f = (m >>= \a -> fstP (f a)) :*: (n >>= \a -> sndP (f a))
-    where
-      fstP (a :*: _) = a
-      sndP (_ :*: b) = b
-
-instance (MonadPlus f, MonadPlus g) => MonadPlus (f :*: g) where
-#  if !(MIN_VERSION_base(4,8,0))
-  mzero = mzero :*: mzero
-  (x1 :*: y1) `mplus` (x2 :*: y2) =  (x1 `mplus` x2) :*: (y1 `mplus` y2)
-#  endif
-
-instance (Applicative f, Applicative g) => Applicative (f :.: g) where
-  pure x = Comp1 (pure (pure x))
-  Comp1 f <*> Comp1 x = Comp1 (fmap (<*>) f <*> x)
-
-instance (Alternative f, Applicative g) => Alternative (f :.: g) where
-  empty = Comp1 empty
-  Comp1 x <|> Comp1 y = Comp1 (x <|> y)
-
-deriving instance (Data (f p), Typeable1 f, Data p) => Data (Rec1 f p)
-deriving instance (Data p, Data (f p), Typeable c, Typeable i, Typeable1 f)
-  => Data (M1 i c f p)
-deriving instance (Typeable1 f, Typeable1 g, Data p, Data (f p), Data (g p))
-  => Data ((f :+: g) p)
-deriving instance (Typeable1 f, Typeable1 g, Data p, Data (f p), Data (g p))
-  => Data ((f :*: g) p)
-deriving instance (Typeable1 f, Typeable1 g, Data p, Data (f (g p)))
-  => Data ((f :.: g) p)
-
-#  if MIN_VERSION_base(4,8,0)
-instance Bifunctor (K1 i) where
-    bimap f _ (K1 c) = K1 (f c)
-#  endif
-# endif
-#endif
-
 #if !(MIN_VERSION_base(4,10,0))
-# if MIN_VERSION_base(4,9,0)
 deriving instance (Typeable k, Data a, Typeable (b :: k)) => Data (Const a b)
-# else
-deriving instance (Data a, Data b) => Data (Const a b)
-# endif
 
-# if MIN_VERSION_base(4,9,0)
 instance Eq1 NonEmpty where
   liftEq eq (a :| as) (b :| bs) = eq a b && liftEq eq as bs
 
@@ -962,7 +92,7 @@ instance Show1 NonEmpty where
 instance Semigroup a => Semigroup (IO a) where
     (<>) = liftA2 (<>)
 
-#  if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
+# if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
 instance Semigroup Event where
     (<>) = mappend
     stimes = stimesMonoid
@@ -970,7 +100,6 @@ instance Semigroup Event where
 instance Semigroup Lifetime where
     (<>) = mappend
     stimes = stimesMonoid
-#  endif
 # endif
 #endif
 
@@ -997,7 +126,6 @@ instance Monoid a => Monoid (Strict.ST s a) where
     mempty = pure mempty
     mappend = liftA2 mappend
 
-# if MIN_VERSION_base(4,9,0)
 instance Fail.MonadFail (Strict.ST s) where
     fail s = errorWithoutStackTrace s
 
@@ -1005,7 +133,6 @@ deriving instance Semigroup a => Semigroup (Down a)
 
 instance Semigroup a => Semigroup (Strict.ST s a) where
     (<>) = liftA2 (<>)
-# endif
 
 # if MIN_VERSION_base(4,10,0)
 deriving instance Data IntPtr
@@ -1058,11 +185,8 @@ instance MonadFix Down where
 deriving instance Data a => Data (Down a)
 deriving instance F.Foldable Down
 deriving instance T.Traversable Down
-# if MIN_VERSION_base(4,4,0)
 instance MonadZip Down where
     mzipWith = liftM2
-# endif
-# if MIN_VERSION_base(4,9,0)
 instance Eq1 Down where
     liftEq eq (Down x) (Down y) = eq x y
 instance Ord1 Down where
@@ -1075,33 +199,30 @@ instance Read1 Down where
          readsUnaryWith rp "Down" Down
 instance Show1 Down where
     liftShowsPrec sp _ d (Down x) = showsUnaryWith sp "Down" d x
-# endif
 
-# if __GLASGOW_HASKELL__ >= 701
 instance Monoid c => Applicative (K1 i c) where
   pure _ = K1 mempty
   (<*>) = coerce (mappend :: c -> c -> c)
-#  if MIN_VERSION_base(4,10,0)
+# if MIN_VERSION_base(4,10,0)
   liftA2 = \_ -> coerce (mappend :: c -> c -> c)
-#  endif
+# endif
 
 instance Monoid (U1 p) where
   mempty = U1
-#  if !(MIN_VERSION_base(4,11,0))
+# if !(MIN_VERSION_base(4,11,0))
   _ `mappend` _ = U1
-#  endif
+# endif
 deriving instance Monoid p => Monoid (Par1 p)
 deriving instance Monoid (f p) => Monoid (Rec1 f p)
 deriving instance Monoid c => Monoid (K1 i c p)
 deriving instance Monoid (f p) => Monoid (M1 i c f p)
 instance (Monoid (f p), Monoid (g p)) => Monoid ((f :*: g) p) where
   mempty = mempty :*: mempty
-#  if !(MIN_VERSION_base(4,11,0))
+# if !(MIN_VERSION_base(4,11,0))
   (x1 :*: y1) `mappend` (x2 :*: y2) = (x1 `mappend` x2) :*: (y1 `mappend` y2)
-#  endif
+# endif
 deriving instance Monoid (f (g p)) => Monoid ((f :.: g) p)
 
-#  if MIN_VERSION_base(4,9,0)
 instance Semigroup (V1 p) where
   v <> _ = v
 instance Semigroup (U1 p) where
@@ -1113,13 +234,9 @@ deriving instance Semigroup (f p) => Semigroup (M1 i c f p)
 instance (Semigroup (f p), Semigroup (g p)) => Semigroup ((f :*: g) p) where
   (x1 :*: y1) <> (x2 :*: y2) = (x1 <> x2) :*: (y1 <> y2)
 deriving instance Semigroup (f (g p)) => Semigroup ((f :.: g) p)
-#  endif
-# endif
 
-# if MIN_VERSION_base(4,8,0)
 deriving instance Foldable f => Foldable (Alt f)
 deriving instance Traversable f => Traversable (Alt f)
-# endif
 #endif
 
 #if !(MIN_VERSION_base(4,14,0))
@@ -1135,9 +252,6 @@ instance (Monoid a, Monoid b) => Monad ((,,) a b) where
       case k a of
         (u', v', b) ->
           (u `mappend` u', v `mappend` v', b)
-# if !(MIN_VERSION_base(4,8,0))
-    return x = (mempty, mempty, x)
-# endif
 
 instance Functor ((,,,) a b c) where
     fmap f (a, b, c, d) = (a, b, c, f d)
@@ -1152,9 +266,6 @@ instance (Monoid a, Monoid b, Monoid c) => Monad ((,,,) a b c) where
       case k a of
         (u', v', w', b) ->
           (u `mappend` u', v `mappend` v', w `mappend` w', b)
-# if !(MIN_VERSION_base(4,8,0))
-    return x = (mempty, mempty, mempty, x)
-# endif
 
 deriving instance Functor m => Functor (Kleisli m a)
 
@@ -1177,10 +288,6 @@ instance Alternative m => Alternative (Kleisli m a) where
 instance Monad m => Monad (Kleisli m a) where
   Kleisli f >>= k = Kleisli $ \x -> f x >>= \a -> runKleisli (k a) x
   {-# INLINE (>>=) #-}
-# if !(MIN_VERSION_base(4,8,0))
-  return = Kleisli . const . return
-  {-# INLINE return #-}
-# endif
 
 instance MonadPlus m => MonadPlus (Kleisli m a) where
   mzero = Kleisli $ const mzero
@@ -1201,9 +308,7 @@ deriving instance Real       a => Real       (Down a)
 deriving instance RealFrac   a => RealFrac   (Down a)
 deriving instance RealFloat  a => RealFloat  (Down a)
 deriving instance Storable   a => Storable   (Down a)
-# if MIN_VERSION_base(4,7,0)
 deriving instance FiniteBits a => FiniteBits (Down a)
-# endif
 
 deriving instance (Typeable2 a, Typeable b, Typeable c, Data (a b c))
                          => Data (WrappedArrow a b c)
@@ -1211,20 +316,16 @@ deriving instance (Typeable1 m, Typeable a, Data (m a))
                          => Data (WrappedMonad m a)
 deriving instance Data a => Data (ZipList a)
 
-# if MIN_VERSION_base(4,7,0)
 instance IsList (ZipList a) where
   type Item (ZipList a) = a
   fromList = ZipList
   toList = getZipList
-# endif
 
-# if MIN_VERSION_base(4,9,0)
 instance (TestEquality f) => TestEquality (Compose f g) where
   testEquality (Compose x) (Compose y) =
     case testEquality x y of -- :: Maybe (g x :~: g y)
       Just Refl -> Just Refl -- :: Maybe (x :~: y)
       Nothing   -> Nothing
-# endif
 #endif
 
 #if !(MIN_VERSION_base(4,15,0))
@@ -1633,22 +734,19 @@ instance  (Ix a1, Ix a2, Ix a3, Ix a4, Ix a5, Ix a6, Ix a7, Ix a8, Ix a9,
 
     -- Default method for index
 
-# if MIN_VERSION_base(4,4,0)
 instance MonadZip Complex where
   mzipWith = liftA2
 
 instance MonadFix Complex where
   mfix f = (let a :+ _ = f a in a) :+ (let _ :+ a = f a in a)
-# endif
 #endif
 
 #if !(MIN_VERSION_base(4,16,0))
-# if MIN_VERSION_base(4,9,0)
 instance Eq1 Complex where
     liftEq eq (x :+ y) (u :+ v) = eq x u && eq y v
 
 instance Read1 Complex where
-#  if MIN_VERSION_base(4,10,0)
+# if MIN_VERSION_base(4,10,0)
     liftReadPrec rp _  = parens $ prec complexPrec $ do
         x <- step rp
         expectP (Symbol ":+")
@@ -1659,7 +757,7 @@ instance Read1 Complex where
 
     liftReadListPrec = liftReadListPrecDefault
     liftReadList     = liftReadListDefault
-#  else
+# else
     liftReadsPrec rdP _ p s = readParen (p > complexPrec) (\s' -> do
       (x, s'')     <- rdP (complexPrec+1) s'
       (":+", s''') <- lex s''
@@ -1667,7 +765,7 @@ instance Read1 Complex where
       return (x :+ y, s'''')) s
       where
         complexPrec = 6
-#  endif
+# endif
 
 instance Show1 Complex where
     liftShowsPrec sp _ d (x :+ y) = showParen (d > complexPrec) $
@@ -1686,7 +784,7 @@ instance Ord a => Ord2 ((,,) a) where
         comp1 x1 x2 `mappend` comp2 y1 y2
 
 instance Read a => Read2 ((,,) a) where
-#  if MIN_VERSION_base(4,10,0)
+# if MIN_VERSION_base(4,10,0)
     liftReadPrec2 rp1 _ rp2 _ = parens $ paren $ do
         x1 <- readPrec
         expectP (Punc ",")
@@ -1697,7 +795,7 @@ instance Read a => Read2 ((,,) a) where
 
     liftReadListPrec2 = liftReadListPrec2Default
     liftReadList2     = liftReadList2Default
-#  else
+# else
     liftReadsPrec2 rp1 _ rp2 _ _ = readParen False $ \ r ->
         [((e1,e2,e3), y) | ("(",s) <- lex r,
                            (e1,t)  <- readsPrec 0 s,
@@ -1706,7 +804,7 @@ instance Read a => Read2 ((,,) a) where
                            (",",w) <- lex v,
                            (e3,x)  <- rp2 0 w,
                            (")",y) <- lex x]
-#  endif
+# endif
 
 instance Show a => Show2 ((,,) a) where
     liftShowsPrec2 sp1 _ sp2 _ _ (x1,y1,y2)
@@ -1722,14 +820,14 @@ instance (Ord a, Ord b) => Ord1 ((,,) a b) where
     liftCompare = liftCompare2 compare
 
 instance (Read a, Read b) => Read1 ((,,) a b) where
-#  if MIN_VERSION_base(4,10,0)
+# if MIN_VERSION_base(4,10,0)
     liftReadPrec = liftReadPrec2 readPrec readListPrec
 
     liftReadListPrec = liftReadListPrecDefault
     liftReadList     = liftReadListDefault
-#  else
+# else
     liftReadsPrec = liftReadsPrec2 readsPrec readList
-#  endif
+# endif
 
 instance (Show a, Show b) => Show1 ((,,) a b) where
     liftShowsPrec = liftShowsPrec2 showsPrec showList
@@ -1747,7 +845,7 @@ instance (Ord a, Ord b) => Ord2 ((,,,) a b) where
         comp1 x1 x2 `mappend` comp2 y1 y2
 
 instance (Read a, Read b) => Read2 ((,,,) a b) where
-#  if MIN_VERSION_base(4,10,0)
+# if MIN_VERSION_base(4,10,0)
     liftReadPrec2 rp1 _ rp2 _ = parens $ paren $ do
         x1 <- readPrec
         expectP (Punc ",")
@@ -1760,7 +858,7 @@ instance (Read a, Read b) => Read2 ((,,,) a b) where
 
     liftReadListPrec2 = liftReadListPrec2Default
     liftReadList2     = liftReadList2Default
-#  else
+# else
     liftReadsPrec2 rp1 _ rp2 _ _ = readParen False $ \ r ->
         [((e1,e2,e3,e4), s9) | ("(",s1) <- lex r,
                                (e1,s2)  <- readsPrec 0 s1,
@@ -1771,7 +869,7 @@ instance (Read a, Read b) => Read2 ((,,,) a b) where
                                (",",s7) <- lex s6,
                                (e4,s8)  <- rp2 0 s7,
                                (")",s9) <- lex s8]
-#  endif
+# endif
 
 instance (Show a, Show b) => Show2 ((,,,) a b) where
     liftShowsPrec2 sp1 _ sp2 _ _ (x1,x2,y1,y2)
@@ -1788,14 +886,14 @@ instance (Ord a, Ord b, Ord c) => Ord1 ((,,,) a b c) where
     liftCompare = liftCompare2 compare
 
 instance (Read a, Read b, Read c) => Read1 ((,,,) a b c) where
-#  if MIN_VERSION_base(4,10,0)
+# if MIN_VERSION_base(4,10,0)
     liftReadPrec = liftReadPrec2 readPrec readListPrec
 
     liftReadListPrec = liftReadListPrecDefault
     liftReadList     = liftReadListDefault
-#  else
+# else
     liftReadsPrec = liftReadsPrec2 readsPrec readList
-#  endif
+# endif
 
 instance (Show a, Show b, Show c) => Show1 ((,,,) a b c) where
     liftShowsPrec = liftShowsPrec2 showsPrec showList
@@ -1808,9 +906,8 @@ instance (Semigroup (f a), Semigroup (g a)) => Semigroup (Functor.Product f g a)
 
 instance (Monoid (f a), Monoid (g a)) => Monoid (Functor.Product f g a) where
     mempty = Functor.Pair mempty mempty
-#  if !(MIN_VERSION_base(4,11,0))
+# if !(MIN_VERSION_base(4,11,0))
     Functor.Pair x1 y1 `mappend` Functor.Pair x2 y2 = Functor.Pair (x1 `mappend` x2) (y1 `mappend` y2)
-#  endif
 # endif
 
 # if MIN_VERSION_base(4,15,0)
@@ -1853,11 +950,6 @@ instance Ix a => Ix (Solo a) where -- as derived
 #endif
 
 #if !(MIN_VERSION_base(4,16,1))
-# if MIN_VERSION_base(4,5,0)
--- These are guarded on base-4.5.0 because that was the first version which
--- exported their constructors, which is necessary to use
--- GeneralizedNewtypeDeriving. See
--- https://gitlab.haskell.org/ghc/ghc/-/issues/5529.
 deriving instance Ix CChar
 deriving instance Ix CSChar
 deriving instance Ix CUChar
@@ -1877,7 +969,6 @@ deriving instance Ix CIntPtr
 deriving instance Ix CUIntPtr
 deriving instance Ix CIntMax
 deriving instance Ix CUIntMax
-# endif
 # if MIN_VERSION_base(4,10,0)
 deriving instance Ix CBool
 # endif
@@ -1891,53 +982,48 @@ deriving instance Ix WordPtr
 deriving instance Ix IntPtr
 # endif
 
-# if MIN_VERSION_base(4,5,0)
--- These are guarded on base-4.5.0 because that was the first version which
--- exported their constructors, which is necessary to use
--- GeneralizedNewtypeDeriving. See
--- https://gitlab.haskell.org/ghc/ghc/-/issues/5529.
-#  if defined(HTYPE_DEV_T)
+# if defined(HTYPE_DEV_T)
 deriving instance Ix CDev
 # endif
-#  if defined(HTYPE_INO_T)
+# if defined(HTYPE_INO_T)
 deriving instance Ix CIno
-#  endif
-#  if defined(HTYPE_MODE_T)
-deriving instance Ix CMode
-#  endif
-#  if defined(HTYPE_OFF_T)
-deriving instance Ix COff
-#  endif
-#  if defined(HTYPE_PID_T)
-deriving instance Ix CPid
-#  endif
-#  if defined(HTYPE_SSIZE_T)
-deriving instance Ix CSsize
-#  endif
-#  if defined(HTYPE_GID_T)
-deriving instance Ix CGid
-#  endif
-#  if defined(HTYPE_NLINK_T)
-deriving instance Ix CNlink
-#  endif
-#  if defined(HTYPE_UID_T)
-deriving instance Ix CUid
-#  endif
-#  if defined(HTYPE_CC_T)
-deriving instance Ix CCc
-#  endif
-#  if defined(HTYPE_SPEED_T)
-deriving instance Ix CSpeed
-#  endif
-#  if defined(HTYPE_TCFLAG_T)
-deriving instance Ix CTcflag
-#  endif
-#  if defined(HTYPE_RLIM_T)
-deriving instance Ix CRLim
-#  endif
-deriving instance Ix Fd
 # endif
-#  if MIN_VERSION_base(4,10,0)
+# if defined(HTYPE_MODE_T)
+deriving instance Ix CMode
+# endif
+# if defined(HTYPE_OFF_T)
+deriving instance Ix COff
+# endif
+# if defined(HTYPE_PID_T)
+deriving instance Ix CPid
+# endif
+# if defined(HTYPE_SSIZE_T)
+deriving instance Ix CSsize
+# endif
+# if defined(HTYPE_GID_T)
+deriving instance Ix CGid
+# endif
+# if defined(HTYPE_NLINK_T)
+deriving instance Ix CNlink
+# endif
+# if defined(HTYPE_UID_T)
+deriving instance Ix CUid
+# endif
+# if defined(HTYPE_CC_T)
+deriving instance Ix CCc
+# endif
+# if defined(HTYPE_SPEED_T)
+deriving instance Ix CSpeed
+# endif
+# if defined(HTYPE_TCFLAG_T)
+deriving instance Ix CTcflag
+# endif
+# if defined(HTYPE_RLIM_T)
+deriving instance Ix CRLim
+# endif
+deriving instance Ix Fd
+
+# if MIN_VERSION_base(4,10,0)
 #  if defined(HTYPE_BLKSIZE_T)
 deriving instance Ix CBlkSize
 #  endif
@@ -2007,7 +1093,6 @@ instance (Generic1 f, Ord (Rep1 f a)) => Ord (Generically1 f a) where
 #endif
 
 #if !(MIN_VERSION_base(4,19,0))
-# if MIN_VERSION_base(4,9,0)
 deriving instance Enum (f (g a)) => Enum (Compose f g a)
 deriving instance Bounded (f (g a)) => Bounded (Compose f g a)
 deriving instance Num (f (g a)) => Num (Compose f g a)
@@ -2023,13 +1108,12 @@ deriving instance Num (f (g a)) => Num (Compose f g a)
 -- This makes deriving Real and Integral instances slightly more complicated for
 -- these older versions of base, as there are no Real1 or Integral1 classes. We
 -- opt for making the instance contexts more complicated instead.
-#  if MIN_VERSION_base(4,18,0)
+# if MIN_VERSION_base(4,18,0)
 deriving instance Real (f (g a)) => Real (Compose f g a)
 deriving instance Integral (f (g a)) => Integral (Compose f g a)
-#  else
+# else
 deriving instance (Real (f (g a)), Ord1 f, Ord1 g, Ord a) => Real (Compose f g a)
 deriving instance (Integral (f (g a)), Ord1 f, Ord1 g, Ord a) => Integral (Compose f g a)
-#  endif
 # endif
 
 # if MIN_VERSION_base(4,18,0)
@@ -2051,7 +1135,6 @@ instance Ord (SSymbol s) where
 #endif
 
 #if !(MIN_VERSION_base(4,20,0))
-# if MIN_VERSION_base(4,9,0)
 deriving instance Fractional (f (g a)) => Fractional (Compose f g a)
 deriving instance Floating (f (g a)) => Floating (Compose f g a)
 
@@ -2059,628 +1142,11 @@ deriving instance Floating (f (g a)) => Floating (Compose f g a)
 -- above (near the Real/Integral instances for Compose), these
 -- RealFrace/RealFloat instances are slightly more complicated for older
 -- versions of base.
-#  if MIN_VERSION_base(4,18,0)
+# if MIN_VERSION_base(4,18,0)
 deriving instance RealFrac (f (g a)) => RealFrac (Compose f g a)
 deriving instance RealFloat (f (g a)) => RealFloat (Compose f g a)
-#  else
+# else
 deriving instance (RealFrac (f (g a)), Ord1 f, Ord1 g, Ord a) => RealFrac (Compose f g a)
 deriving instance (RealFloat (f (g a)), Ord1 f, Ord1 g, Ord a) => RealFloat (Compose f g a)
-#  endif
 # endif
-#endif
-
-#if __GLASGOW_HASKELL__ < 710
-deriving instance Typeable  All
-deriving instance Typeable  AnnotationWrapper
-deriving instance Typeable  Monoid.Any
-deriving instance Typeable1 ArgDescr
-deriving instance Typeable1 ArgOrder
-deriving instance Typeable  BlockReason
-deriving instance Typeable1 Buffer
-deriving instance Typeable3 BufferCodec
-deriving instance Typeable1 BufferList
-deriving instance Typeable  BufferMode
-deriving instance Typeable  BufferState
-deriving instance Typeable  CFile
-deriving instance Typeable  CFpos
-deriving instance Typeable  CJmpBuf
-deriving instance Typeable2 Const
-deriving instance Typeable  Constr
-deriving instance Typeable  ConstrRep
-deriving instance Typeable  DataRep
-deriving instance Typeable  DataType
-deriving instance Typeable1 Down
-deriving instance Typeable1 Dual
-deriving instance Typeable1 Endo
-deriving instance Typeable  Errno
-deriving instance Typeable1 First
-deriving instance Typeable  Data.Fixity
-deriving instance Typeable  GeneralCategory
-deriving instance Typeable  HandlePosn
-deriving instance Typeable1 Exception.Handler
-deriving instance Typeable  HandleType
-deriving instance Typeable  IODeviceType
-deriving instance Typeable  IOErrorType
-deriving instance Typeable  IOMode
-deriving instance Typeable1 Last
-deriving instance Typeable  Lexeme
-deriving instance Typeable  Newline
-deriving instance Typeable  NewlineMode
-deriving instance Typeable  Opaque
-deriving instance Typeable1 OptDescr
-deriving instance Typeable  Pool
-deriving instance Typeable1 Product
-deriving instance Typeable1 ReadP
-deriving instance Typeable1 ReadPrec
-deriving instance Typeable  SeekMode
-deriving instance Typeable2 Lazy.ST
-deriving instance Typeable2 STret
-deriving instance Typeable1 Sum
-deriving instance Typeable  TextEncoding
-deriving instance Typeable  ThreadStatus
-deriving instance Typeable1 ZipList
-
-# if defined(mingw32_HOST_OS)
-deriving instance Typeable  CodePageArrays
-deriving instance Typeable2 CompactArray
-deriving instance Typeable1 ConvArray
-deriving instance Typeable  Console.Handler
-# endif
-
-# if MIN_VERSION_base(4,3,0)
-deriving instance Typeable  MaskingState
-# endif
-
-# if MIN_VERSION_base(4,4,0)
-deriving instance Typeable  CodingFailureMode
-deriving instance Typeable  CodingProgress
-deriving instance Typeable  Fingerprint
-
-#  if !defined(mingw32_HOST_OS) && !defined(__GHCJS__)
-deriving instance Typeable  Event
-deriving instance Typeable  EventManager
-deriving instance Typeable  FdKey
-deriving instance Typeable  TimeoutKey
-#  endif
-# endif
-
-# if __GLASGOW_HASKELL__ >= 701
-deriving instance Typeable  Arity
-deriving instance Typeable  Associativity
-deriving instance Typeable  C
-deriving instance Typeable  D
-deriving instance Typeable  Generics.Fixity
-deriving instance Typeable3 K1
-deriving instance Typeable  NoSelector
-deriving instance Typeable  P
-deriving instance Typeable1 Par1
-deriving instance Typeable  R
-deriving instance Typeable  S
-deriving instance Typeable1 U1
-deriving instance Typeable1 V1
-
-#  if __GLASGOW_HASKELL__ >= 708
--- Data types which use poly-kinded Typeable...
-deriving instance Typeable (:+:)
-deriving instance Typeable (:*:)
-deriving instance Typeable (:.:)
-deriving instance Typeable M1
-deriving instance Typeable Rec1
-#  else
--- ...but we can hack around that if need be.
-instance (Typeable1 f, Typeable1 g) => Typeable1 (f :+: g) where
-  typeOf1 t = mkTyConApp conSumTyCon [typeOf1 (f t), typeOf1 (g t)]
-    where
-      f :: (f :+: g) p -> f p
-      f = undefined
-
-      g :: (f :+: g) p -> g p
-      g = undefined
-
-conSumTyCon :: TyCon
-conSumTyCon = mkTyCon3 ghcGenericsPackage "GHC.Generics" ":+:"
-
-instance (Typeable1 f, Typeable1 g) => Typeable1 (f :*: g) where
-  typeOf1 t = mkTyConApp conProductTyCon [typeOf1 (f t), typeOf1 (g t)]
-    where
-      f :: (f :*: g) p -> f p
-      f = undefined
-
-      g :: (f :*: g) p -> g p
-      g = undefined
-
-conProductTyCon :: TyCon
-conProductTyCon = mkTyCon3 ghcGenericsPackage "GHC.Generics" ":*:"
-
-instance (Typeable1 f, Typeable1 g) => Typeable1 (f :.: g) where
-  typeOf1 t = mkTyConApp conComposeTyCon [typeOf1 (f t), typeOf1 (g t)]
-    where
-      f :: (f :.: g) p -> f p
-      f = undefined
-
-      g :: (f :.: g) p -> g p
-      g = undefined
-
-conComposeTyCon :: TyCon
-conComposeTyCon = mkTyCon3 ghcGenericsPackage "GHC.Generics" ":.:"
-
-instance (Typeable i, Typeable c, Typeable1 f) => Typeable1 (M1 i c f) where
-  typeOf1 t = mkTyConApp m1TyCon [typeOf (i t), typeOf (c t), typeOf1 (f t)]
-    where
-      i :: M1 i c f p -> i
-      i = undefined
-
-      c :: M1 i c f p -> c
-      c = undefined
-
-      f :: M1 i c f p -> f p
-      f = undefined
-
-m1TyCon :: TyCon
-m1TyCon = mkTyCon3 ghcGenericsPackage "GHC.Generics" "M1"
-
-instance Typeable1 f => Typeable1 (Rec1 f) where
-  typeOf1 t = mkTyConApp rec1TyCon [typeOf1 (f t)]
-    where
-      f :: Rec1 f a -> f a
-      f = undefined
-
-rec1TyCon :: TyCon
-rec1TyCon = mkTyCon3 ghcGenericsPackage "GHC.Generics" "Rec1"
-
-ghcGenericsPackage :: String
-#   if MIN_VERSION_base(4,6,0)
-ghcGenericsPackage = "base"
-#   else
-ghcGenericsPackage = "ghc-prim"
-#   endif
-#  endif
-# endif
-
-# if MIN_VERSION_base(4,5,0)
-deriving instance Typeable  CostCentre
-deriving instance Typeable  CostCentreStack
-deriving instance Typeable  GCStats
-# endif
-
-# if MIN_VERSION_base(4,6,0)
-deriving instance Typeable  CSigset
-deriving instance Typeable  ForeignPtrContents
-deriving instance Typeable  Nat
-deriving instance Typeable1 NoIO
-deriving instance Typeable  Symbol
-# endif
-
-# if MIN_VERSION_ghc_prim(0,3,1)
-deriving instance Typeable  SPEC
-# endif
-
-# if MIN_VERSION_base(4,7,0)
-deriving instance Typeable FieldFormat
-deriving instance Typeable FormatAdjustment
-deriving instance Typeable FormatParse
-deriving instance Typeable FormatSign
-deriving instance Typeable KProxy
-deriving instance Typeable Number
-deriving instance Typeable SomeNat
-deriving instance Typeable SomeSymbol
-deriving instance Typeable QSem -- This instance seems to have been removed
-                                -- (accidentally?) in base-4.7.0.0
-# endif
-
-# if __GLASGOW_HASKELL__ >= 708
--- Data types which use poly-kinded Typeable...
-deriving instance Typeable ArrowMonad
-deriving instance Typeable Kleisli
-deriving instance Typeable WrappedArrow
-deriving instance Typeable WrappedMonad
-deriving instance Typeable Exts.Any
-# else
--- ...but we can hack around that if need be.
-instance Typeable2 a => Typeable1 (ArrowMonad a) where
-  typeOf1 t = mkTyConApp arrowMonadTyCon [typeOf2 (a t)]
-    where
-      a :: ArrowMonad a b -> a () b
-      a = undefined
-
-arrowMonadTyCon :: TyCon
-#  if MIN_VERSION_base(4,4,0)
-arrowMonadTyCon = mkTyCon3 "base" "Control.Arrow" "ArrowMonad"
-#  else
-arrowMonadTyCon = mkTyCon "Control.Arrow.ArrowMonad"
-#  endif
-
-instance Typeable1 m => Typeable2 (Kleisli m) where
-  typeOf2 t = mkTyConApp kleisliTyCon [typeOf1 (m t)]
-    where
-      m :: Kleisli m a b -> m b
-      m = undefined
-
-kleisliTyCon :: TyCon
-#  if MIN_VERSION_base(4,4,0)
-kleisliTyCon = mkTyCon3 "base" "Control.Arrow" "Kleisli"
-#  else
-kleisliTyCon = mkTyCon "Control.Arrow.Kleisli"
-#  endif
-
-instance Typeable2 a => Typeable2 (WrappedArrow a) where
-  typeOf2 t = mkTyConApp wrappedArrowTyCon [typeOf2 (a t)]
-    where
-      a :: WrappedArrow a b c -> a b c
-      a = undefined
-
-wrappedArrowTyCon :: TyCon
-#  if MIN_VERSION_base(4,4,0)
-wrappedArrowTyCon = mkTyCon3 "base" "Control.Applicative" "WrappedArrow"
-#  else
-wrappedArrowTyCon = mkTyCon "Control.Applicative.WrappedArrow"
-#  endif
-
-instance Typeable1 m => Typeable1 (WrappedMonad m) where
-  typeOf1 t = mkTyConApp wrappedMonadTyCon [typeOf1 (m t)]
-    where
-      m :: WrappedMonad m a -> m a
-      m = undefined
-
-wrappedMonadTyCon :: TyCon
-#  if MIN_VERSION_base(4,4,0)
-wrappedMonadTyCon = mkTyCon3 "base" "Control.Applicative" "WrappedMonad"
-#  else
-wrappedMonadTyCon = mkTyCon "Control.Applicative.WrappedMonad"
-#  endif
-
--- GHC will get confused if you try deriving a Typeable instance for Any
--- prior to GHC 7.8, sadly
-instance Typeable Exts.Any where
-  typeOf _ = mkTyConApp anyTyCon []
-
-anyTyCon :: TyCon
-#  if MIN_VERSION_base(4,4,0)
-anyTyCon = mkTyCon3 "ghc-prim" "GHC.Prim" "Any"
-#  else
-anyTyCon = mkTyCon "GHC.Prim.Any"
-#  endif
-# endif
-
-# if __GLASGOW_HASKELL__ >= 708
--- Data types which have more than seven type arguments
-deriving instance Typeable (,,,,,,,)
-deriving instance Typeable (,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-
--- Typeclasses
-deriving instance Typeable Arrow
-deriving instance Typeable ArrowApply
-deriving instance Typeable ArrowChoice
-deriving instance Typeable ArrowLoop
-deriving instance Typeable ArrowZero
-deriving instance Typeable Bits
-deriving instance Typeable Bounded
-deriving instance Typeable BufferedIO
-deriving instance Typeable Category
-deriving instance Typeable Coercible
-deriving instance Typeable Constructor
-deriving instance Typeable Data
-deriving instance Typeable Datatype
-deriving instance Typeable Enum
-deriving instance Typeable Exception
-deriving instance Typeable Eq
-deriving instance Typeable FiniteBits
-deriving instance Typeable Floating
-deriving instance Typeable F.Foldable
-deriving instance Typeable Fractional
-deriving instance Typeable Functor
-deriving instance Typeable Generic
-deriving instance Typeable Generic1
-deriving instance Typeable GHCiSandboxIO
-deriving instance Typeable HasResolution
-deriving instance Typeable HPrintfType
-deriving instance Typeable Integral
-deriving instance Typeable IODevice
-deriving instance Typeable IP
-deriving instance Typeable IsChar
-deriving instance Typeable IsList
-deriving instance Typeable IsString
-deriving instance Typeable Ix
-deriving instance Typeable KnownNat
-deriving instance Typeable KnownSymbol
-deriving instance Typeable Monad
-deriving instance Typeable MonadFix
-deriving instance Typeable MonadPlus
-deriving instance Typeable MonadZip
-deriving instance Typeable Num
-deriving instance Typeable Ord
-deriving instance Typeable PrintfArg
-deriving instance Typeable PrintfType
-deriving instance Typeable RawIO
-deriving instance Typeable Read
-deriving instance Typeable Real
-deriving instance Typeable RealFloat
-deriving instance Typeable RealFrac
-deriving instance Typeable Selector
-deriving instance Typeable Show
-deriving instance Typeable Storable
-deriving instance Typeable TestCoercion
-deriving instance Typeable TestEquality
-deriving instance Typeable T.Traversable
-deriving instance Typeable Typeable
-
--- Constraints
-deriving instance Typeable (~)
-deriving instance Typeable Constraint
-deriving instance Typeable (() :: Constraint)
-
--- Promoted data constructors
-deriving instance Typeable '()
-deriving instance Typeable '(,)
-deriving instance Typeable '(,,)
-deriving instance Typeable '(,,,)
-deriving instance Typeable '(,,,,)
-deriving instance Typeable '(,,,,,)
-deriving instance Typeable '(,,,,,,)
-deriving instance Typeable '(,,,,,,,)
-deriving instance Typeable '(,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
-deriving instance Typeable '[]
-deriving instance Typeable '(:)
-deriving instance Typeable '(:%)
-deriving instance Typeable '(:+)
-deriving instance Typeable 'AbsoluteSeek
-deriving instance Typeable 'All
-deriving instance Typeable 'AlreadyExists
-deriving instance Typeable 'Monoid.Any
-deriving instance Typeable 'AppendHandle
-deriving instance Typeable 'AppendMode
-deriving instance Typeable 'BlockedIndefinitelyOnMVar
-deriving instance Typeable 'BlockedIndefinitelyOnSTM
-deriving instance Typeable 'BlockedOnBlackHole
-deriving instance Typeable 'BlockedOnException
-deriving instance Typeable 'BlockedOnForeignCall
-deriving instance Typeable 'BlockedOnMVar
-deriving instance Typeable 'BlockedOnOther
-deriving instance Typeable 'BlockedOnSTM
-deriving instance Typeable 'ClosedHandle
-deriving instance Typeable 'ClosePunctuation
-deriving instance Typeable 'ConnectorPunctuation
-deriving instance Typeable 'Const
-deriving instance Typeable 'Control
-deriving instance Typeable 'CRLF
-deriving instance Typeable 'CurrencySymbol
-deriving instance Typeable 'DashPunctuation
-deriving instance Typeable 'Deadlock
-deriving instance Typeable 'DecimalNumber
-deriving instance Typeable 'Denormal
-deriving instance Typeable 'Directory
-deriving instance Typeable 'DivideByZero
-deriving instance Typeable 'Down
-deriving instance Typeable 'Dual
-deriving instance Typeable 'EnclosingMark
-deriving instance Typeable 'Endo
-deriving instance Typeable 'Exception.EOF
-deriving instance Typeable 'EQ
-deriving instance Typeable 'ErrorOnCodingFailure
-deriving instance Typeable 'False
-deriving instance Typeable 'FinalQuote
-deriving instance Typeable 'First
-deriving instance Typeable 'ForceSpecConstr
-deriving instance Typeable 'Format
-deriving instance Typeable 'GT
-deriving instance Typeable 'HardwareFault
-deriving instance Typeable 'HeapOverflow
-deriving instance Typeable 'IgnoreCodingFailure
-deriving instance Typeable 'IllegalOperation
-deriving instance Typeable 'InappropriateType
-deriving instance Typeable 'Data.Infix
-deriving instance Typeable 'InitialQuote
-deriving instance Typeable 'InputUnderflow
-deriving instance Typeable 'Interrupted
-deriving instance Typeable 'InvalidArgument
-deriving instance Typeable 'InvalidSequence
-deriving instance Typeable 'Just
-deriving instance Typeable 'K1
-deriving instance Typeable 'KProxy
-deriving instance Typeable 'Last
-deriving instance Typeable 'Left
-deriving instance Typeable 'LeftAdjust
-deriving instance Typeable 'LeftAssociative
-deriving instance Typeable 'LetterNumber
-deriving instance Typeable 'LF
-deriving instance Typeable 'LineSeparator
-deriving instance Typeable 'LossOfPrecision
-deriving instance Typeable 'LowercaseLetter
-deriving instance Typeable 'LT
-deriving instance Typeable 'MaskedInterruptible
-deriving instance Typeable 'MaskedUninterruptible
-deriving instance Typeable 'MathSymbol
-deriving instance Typeable 'ModifierLetter
-deriving instance Typeable 'ModifierSymbol
-deriving instance Typeable 'NestedAtomically
-deriving instance Typeable 'NewlineMode
-deriving instance Typeable 'NonSpacingMark
-deriving instance Typeable 'NonTermination
-deriving instance Typeable 'NoSpecConstr
-deriving instance Typeable 'NoSuchThing
-deriving instance Typeable 'NotAssigned
-deriving instance Typeable 'NotAssociative
-deriving instance Typeable 'Nothing
-deriving instance Typeable 'O
-deriving instance Typeable 'OpenPunctuation
-deriving instance Typeable 'OtherError
-deriving instance Typeable 'OtherLetter
-deriving instance Typeable 'OtherNumber
-deriving instance Typeable 'OtherPunctuation
-deriving instance Typeable 'OtherSymbol
-deriving instance Typeable 'OutputUnderflow
-deriving instance Typeable 'Overflow
-deriving instance Typeable 'Par1
-deriving instance Typeable 'ParagraphSeparator
-deriving instance Typeable 'PermissionDenied
-deriving instance Typeable 'Data.Prefix
-deriving instance Typeable 'PrivateUse
-deriving instance Typeable 'Product
-deriving instance Typeable 'ProtocolError
-deriving instance Typeable 'RatioZeroDenominator
-deriving instance Typeable 'RawDevice
-deriving instance Typeable 'ReadBuffer
-deriving instance Typeable 'ReadHandle
-deriving instance Typeable 'ReadMode
-deriving instance Typeable 'ReadWriteHandle
-deriving instance Typeable 'ReadWriteMode
-deriving instance Typeable 'RegularFile
-deriving instance Typeable 'RelativeSeek
-deriving instance Typeable 'ResourceBusy
-deriving instance Typeable 'ResourceExhausted
-deriving instance Typeable 'ResourceVanished
-deriving instance Typeable 'Right
-deriving instance Typeable 'RightAssociative
-deriving instance Typeable 'RoundtripFailure
-deriving instance Typeable 'SeekFromEnd
-deriving instance Typeable 'SemiClosedHandle
-deriving instance Typeable 'SignPlus
-deriving instance Typeable 'SignSpace
-deriving instance Typeable 'Space
-deriving instance Typeable 'SpacingCombiningMark
-deriving instance Typeable 'SPEC
-deriving instance Typeable 'SPEC2
-deriving instance Typeable 'StackOverflow
-deriving instance Typeable 'Stream
-deriving instance Typeable 'Sum
-deriving instance Typeable 'Surrogate
-deriving instance Typeable 'SystemError
-deriving instance Typeable 'ThreadBlocked
-deriving instance Typeable 'ThreadDied
-deriving instance Typeable 'ThreadFinished
-deriving instance Typeable 'ThreadKilled
-deriving instance Typeable 'ThreadRunning
-deriving instance Typeable 'TimeExpired
-deriving instance Typeable 'TitlecaseLetter
-deriving instance Typeable 'TransliterateCodingFailure
-deriving instance Typeable 'True
-deriving instance Typeable 'U1
-deriving instance Typeable 'Underflow
-deriving instance Typeable 'Unmasked
-deriving instance Typeable 'UnsatisfiedConstraints
-deriving instance Typeable 'UnsupportedOperation
-deriving instance Typeable 'UppercaseLetter
-deriving instance Typeable 'UserError
-deriving instance Typeable 'UserInterrupt
-deriving instance Typeable 'WriteBuffer
-deriving instance Typeable 'WriteHandle
-deriving instance Typeable 'WriteMode
-deriving instance Typeable 'ZeroPad
-deriving instance Typeable 'ZipList
-
-#  if defined(mingw32_HOST_OS)
-deriving instance Typeable 'Break
-deriving instance Typeable 'Close
-deriving instance Typeable 'ControlC
-deriving instance Typeable 'Logoff
-deriving instance Typeable 'Shutdown
-#  endif
-# endif
-
 #endif

--- a/src/Data/Orphans/Prelude.hs
+++ b/src/Data/Orphans/Prelude.hs
@@ -1,16 +1,13 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE KindSignatures #-}
-
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ExplicitNamespaces #-}
-#endif
 
 #if __GLASGOW_HASKELL__ >= 806
 {-# LANGUAGE NoStarIsType #-}
 #endif
 
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 {-|
 Exports modules that Data.Orphans needs. Because Data.Orphans uses several modules
@@ -42,21 +39,26 @@ import Control.Category as OrphansPrelude hiding ((.), id)
 import Control.Concurrent.QSem as OrphansPrelude
 import Control.Monad as OrphansPrelude hiding (mapM, sequence)
 import Control.Monad.Fix as OrphansPrelude
+import Control.Monad.Zip as OrphansPrelude
 
+import Data.Bifunctor as OrphansPrelude
 import Data.Bits as OrphansPrelude
 import Data.Char as OrphansPrelude
 import Data.Complex as OrphansPrelude (Complex(..))
 import Data.Data as OrphansPrelude (Data(..), Constr, DataType, mkConstr, mkDataType)
 import Data.Fixed as OrphansPrelude
+import Data.Functor.Classes as OrphansPrelude
+import Data.Functor.Compose as OrphansPrelude
+import Data.Functor.Identity as OrphansPrelude
 import Data.Int as OrphansPrelude
 import Data.List as OrphansPrelude (genericLength)
-import Data.Monoid as OrphansPrelude
-  hiding ( Any(..)
-# if MIN_VERSION_base(4,5,0)
-         , (<>)
-# endif
-         )
+import Data.Monoid as OrphansPrelude hiding (Any(..), (<>))
+import Data.Ord as OrphansPrelude (Down(..))
+import Data.Proxy as OrphansPrelude
+import Data.Semigroup as OrphansPrelude (stimesMonoid)
 import Data.String as OrphansPrelude (IsString)
+import Data.Type.Coercion as OrphansPrelude (Coercion, TestCoercion)
+import Data.Type.Equality as OrphansPrelude ((:~:)(..), TestEquality(..))
 import Data.Typeable as OrphansPrelude (Typeable)
 import Data.Version as OrphansPrelude
 import Data.Word as OrphansPrelude
@@ -71,15 +73,22 @@ import GHC.Arr as OrphansPrelude (Ix(..))
 import GHC.Base as OrphansPrelude
 import GHC.Conc as OrphansPrelude
 import GHC.Desugar as OrphansPrelude (AnnotationWrapper)
+import GHC.Exts as OrphansPrelude (IsList(..))
+import GHC.Fingerprint as OrphansPrelude
 import GHC.ForeignPtr as OrphansPrelude
+import GHC.GHCi as OrphansPrelude
 import GHC.IO.Buffer as OrphansPrelude
 import GHC.IO.BufferedIO as OrphansPrelude (BufferedIO)
 import GHC.IO.Device as OrphansPrelude (IODevice, IODeviceType(..), RawIO)
 import GHC.IO.Encoding as OrphansPrelude
+import GHC.IO.Encoding.Failure as OrphansPrelude
 import GHC.IO.Handle as OrphansPrelude
 import GHC.IO.Handle.Types as OrphansPrelude
 import GHC.Real as OrphansPrelude (Ratio(..), (%))
 import GHC.ST as OrphansPrelude
+import GHC.Stack as OrphansPrelude
+import GHC.Stats as OrphansPrelude
+import GHC.TypeLits as OrphansPrelude hiding (type (*))
 
 import Numeric as OrphansPrelude (showHex)
 
@@ -90,6 +99,7 @@ import System.Posix.Types as OrphansPrelude
 
 import Text.Printf as OrphansPrelude
 import Text.Read as OrphansPrelude
+import Text.Read.Lex as OrphansPrelude (Number)
 
 import Unsafe.Coerce as OrphansPrelude (unsafeCoerce)
 
@@ -97,58 +107,11 @@ import Unsafe.Coerce as OrphansPrelude (unsafeCoerce)
 import GHC.IO.Encoding.CodePage.Table as OrphansPrelude
 # endif
 
-# if MIN_VERSION_base(4,4,0)
-import Control.Monad.Zip as OrphansPrelude
-import GHC.Fingerprint as OrphansPrelude
-import GHC.IO.Encoding.Failure as OrphansPrelude
-
-#  if !defined(mingw32_HOST_OS) && !defined(__GHCJS__)
+# if !defined(mingw32_HOST_OS) && !defined(__GHCJS__)
 import GHC.Event as OrphansPrelude
-#   if !(MIN_VERSION_base(4,7,0))
-      hiding (step)
-#   endif
-#  endif
 # endif
 
-# if MIN_VERSION_base(4,5,0)
-import GHC.Stack as OrphansPrelude
-import GHC.Stats as OrphansPrelude
-# endif
-
-# if MIN_VERSION_base(4,6,0)
-import Data.Ord as OrphansPrelude (Down(..))
-import GHC.GHCi as OrphansPrelude
-import GHC.TypeLits as OrphansPrelude hiding (type (*))
-# else
-import GHC.Exts as OrphansPrelude (Down(..))
-# endif
-
-# if MIN_VERSION_base(4,6,0) && !(MIN_VERSION_base(4,8,2))
-import GHC.IP as OrphansPrelude
-# endif
-
-# if MIN_VERSION_base(4,7,0)
-import Data.Proxy as OrphansPrelude
-import Data.Type.Coercion as OrphansPrelude (Coercion, TestCoercion)
-import Data.Type.Equality as OrphansPrelude ((:~:)(..), TestEquality(..))
-import GHC.Exts as OrphansPrelude (IsList(..))
-import Text.Read.Lex as OrphansPrelude (Number)
-# else
-import Control.Concurrent.SampleVar as OrphansPrelude
-# endif
-
-# if MIN_VERSION_base(4,8,0)
-import Data.Bifunctor as OrphansPrelude
-import Data.Functor.Identity as OrphansPrelude
-#endif
-
-# if MIN_VERSION_base(4,9,0)
-import Data.Functor.Classes as OrphansPrelude
-import Data.Functor.Compose as OrphansPrelude
-import Data.Semigroup as OrphansPrelude (stimesMonoid)
-# endif
-
-# if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,12,0))
+# if !(MIN_VERSION_base(4,12,0))
 import Data.List.NonEmpty as OrphansPrelude (NonEmpty(..))
 import Data.Semigroup as OrphansPrelude (Semigroup(..))
 # endif
@@ -163,11 +126,7 @@ import GHC.Generics as OrphansPrelude ( Generic(..), Generic1(..)
                                       , Generically(..), Generically1(..) )
 # endif
 
-# if MIN_VERSION_base(4,4,0)
 realPart, imagPart :: Complex a -> a
-# else
-realPart, imagPart :: RealFloat a => Complex a -> a
-# endif
 realPart (x :+ _) = x
 imagPart (_ :+ y) = y
 

--- a/test/Data/Bits/OrphansSpec.hs
+++ b/test/Data/Bits/OrphansSpec.hs
@@ -1,25 +1,18 @@
-{-# LANGUAGE CPP #-}
 module Data.Bits.OrphansSpec (main, spec) where
 
 import Test.Hspec
 
-#if MIN_VERSION_base(4,6,0)
 import Data.Bits
 import Data.Orphans ()
-#endif
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
 spec =
-#if MIN_VERSION_base(4,6,0)
   describe "Bits Bool instance" $
     it "allows bitwise operations on Bools" $ do
       True  .&. True  `shouldBe` True
       True  .&. False `shouldBe` False
       False .&. True  `shouldBe` False
       False .&. False `shouldBe` False
-#else
-  return ()
-#endif

--- a/test/Data/Version/OrphansSpec.hs
+++ b/test/Data/Version/OrphansSpec.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE OverloadedLists #-}
-#endif
 module Data.Version.OrphansSpec (main, spec) where
 
 import Test.Hspec
@@ -32,8 +30,6 @@ spec = do
         "Data.Version.Version"
 #endif
 
-#if MIN_VERSION_base(4,7,0)
   describe "IsList Version instance" $
     it "creates a Version from an Int list" $
       [1,2,3] `shouldBe` Version [1,2,3] []
-#endif

--- a/test/GHC/Fingerprint/OrphansSpec.hs
+++ b/test/GHC/Fingerprint/OrphansSpec.hs
@@ -1,29 +1,22 @@
-{-# LANGUAGE CPP #-}
 module GHC.Fingerprint.OrphansSpec (main, spec) where
 
 import Test.Hspec
 
-#if MIN_VERSION_base(4,4,0)
 import Data.Orphans ()
 import Data.Word (Word64)
 import GHC.Fingerprint.Type
-#endif
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
 spec =
-#if MIN_VERSION_base(4,4,0)
   describe "Fingerprint" $
     it "has a Show instance" $ do
       let w1, w2 :: Word64
           w1 = 0x0123456789abcdef
           w2 = 0x42
-          
+
           f :: Fingerprint
           f = Fingerprint w1 w2
       show f `shouldBe` "0123456789abcdef0000000000000042"
-#else
-  return ()
-#endif


### PR DESCRIPTION
Unfortunately, it is no longer possible to reasonably test versions of GHC prior to 8.0 on modern versions of Linux, macOS, or Windows, as these versions of GHC all run into subtle OS incompatibility issues. While we could leave all of the old, pre-8.0 code paths around in `base-orphans`, this runs the risk of bitrotting very quickly. As such, I have opted to remove these code paths here. Given that GHC 7.10.3 was released nearly a decade ago, I believe that the risk of breaking anyone's workflows by doing this is very minimal.

(It's somewhat unfortunate that we have to drop compatibility like this in an explicitly compatibility-oriented library like `base-orphans`, but so be it.)